### PR TITLE
feat(webhooks): add channel routing (CB-32)

### DIFF
--- a/CabrosBot.postman_collection.json
+++ b/CabrosBot.postman_collection.json
@@ -130,7 +130,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"text\": \"BTCUSDT: Price breakout above $85,000 with strong volume\"\n}"
+							"raw": "{\n  \"text\": \"BTCUSDT: Price breakout above $85,000 with strong volume\",\n  \"channels\": [\"telegram\"],\n  \"telegramChatId\": \"-1001234567890\"\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/webhook/alert",
@@ -179,7 +179,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"symbols\": [\"BINANCE:BTCUSDT\", \"NASDAQ:NVDA\"],\n  \"timeframe\": \"1D\"\n}"
+							"raw": "{\n  \"symbols\": [\"BINANCE:BTCUSDT\", \"NASDAQ:NVDA\"],\n  \"timeframe\": \"1D\",\n  \"channels\": [\"telegram\"],\n  \"telegramChatId\": \"-1001234567890\"\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/webhook/expanded-analysis-alert",
@@ -217,7 +217,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"exchange\": \"BINANCE\",\n  \"timeframe\": \"4h\",\n  \"scans\": [\"top_gainers\", \"top_losers\", \"volume_breakout_scanner\"],\n  \"limit\": 5\n}"
+							"raw": "{\n  \"exchange\": \"BINANCE\",\n  \"timeframe\": \"4h\",\n  \"scans\": [\"top_gainers\", \"top_losers\", \"volume_breakout_scanner\"],\n  \"limit\": 5,\n  \"channels\": [\"telegram\"]\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/webhook/market-scanner-alert",
@@ -466,8 +466,13 @@
 					"request": {
 						"method": "POST",
 						"header": [
+							{ "key": "Content-Type", "value": "application/json", "type": "text" },
 							{ "key": "x-api-key", "value": "{{apiKey}}", "type": "text" }
 						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"channels\": [\"telegram\"],\n  \"telegramChatId\": \"-1001234567890\"\n}"
+						},
 						"url": {
 							"raw": "{{baseUrl}}/api/scanner-presets/{{presetId}}/run",
 							"host": ["{{baseUrl}}"],
@@ -523,7 +528,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"crypto\": [\"BTCUSDT\", \"ETHUSD\"],\n  \"stocks\": [\"NVDA\", \"MSFT\"]\n}"
+							"raw": "{\n  \"crypto\": [\"BTCUSDT\", \"ETHUSD\"],\n  \"stocks\": [\"NVDA\", \"MSFT\"],\n  \"channels\": [\"telegram\"]\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/news-monitor",
@@ -545,7 +550,8 @@
 							"path": ["api", "news-monitor"],
 							"query": [
 								{ "key": "crypto", "value": "BTCUSDT,ETHUSD" },
-								{ "key": "stocks", "value": "NVDA" }
+								{ "key": "stocks", "value": "NVDA" },
+								{ "key": "channels", "value": "telegram" }
 							]
 						}
 					}
@@ -918,7 +924,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"type\": \"expanded-analysis\",\n  \"symbols\": [\"BINANCE:BTCUSDT\"],\n  \"timeframe\": \"1D\",\n  \"includeMultiTimeframe\": true\n}"
+							"raw": "{\n  \"type\": \"expanded-analysis\",\n  \"symbols\": [\"BINANCE:BTCUSDT\"],\n  \"timeframe\": \"1D\",\n  \"includeMultiTimeframe\": true,\n  \"channels\": [\"telegram\"],\n  \"telegramChatId\": \"-1001234567890\"\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/jobs/tradingview-analysis",
@@ -983,7 +989,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"type\": \"market-scanner\",\n  \"exchange\": \"BINANCE\",\n  \"timeframe\": \"4h\",\n  \"scans\": [\"top_gainers\", \"top_losers\"],\n  \"limit\": 5\n}"
+							"raw": "{\n  \"type\": \"market-scanner\",\n  \"exchange\": \"BINANCE\",\n  \"timeframe\": \"4h\",\n  \"scans\": [\"top_gainers\", \"top_losers\"],\n  \"limit\": 5,\n  \"channels\": [\"telegram\"]\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/jobs/tradingview-analysis",

--- a/agents.md
+++ b/agents.md
@@ -38,6 +38,7 @@ This project is a small Express + Telegraf (Telegram) bot service that exposes a
 - `src/controllers/webhooks/handlers/expandedAnalysisAlert/expandedAnalysisAlert.js` — `POST /api/webhook/expanded-analysis-alert` handler that builds TradingView MCP analysis reports and sends them through notification channels.
 - `src/controllers/webhooks/handlers/volumeConfirmation/volumeConfirmation.js` — `POST /api/webhook/volume-confirmation` handler that returns structured TradingView MCP volume-confirmation data.
 - `src/controllers/webhooks/handlers/jobs/jobs.js` — Job creation (`POST /api/jobs/tradingview-analysis`) and status polling (`GET /api/jobs/:jobId`) handler.
+- `src/services/notification/requestRouting.js` — Shared optional channel-routing validator/dispatcher for alert-producing routes (`channels`, `telegramChatId`, `whatsappChatId`) that preserves legacy broadcast behavior when `channels` is omitted.
 - `src/controllers/alerts/alerts.js` — Stored alert read, export, analytics, and replay handlers for `GET /api/alerts`, `GET /api/alerts/export`, `GET /api/alerts/summary`, `GET /api/alerts/:alertId`, and `POST /api/alerts/:alertId/replay`.
 - `src/controllers/status.js` — Status handler that computes capabilities, feature flags, notification channels, and active dependencies status.
 - `src/controllers/webhooks/handlers/marketScanner/marketScanner.js` — Scanner webhook handler executing sequential gainers, losers, and breakouts scanner runs on TradingView MCP.
@@ -146,6 +147,10 @@ Implement the following security practices to safeguard endpoints and credential
 - Bot startup is gated: bot is launched only when `ENABLE_TELEGRAM_BOT === 'true'` and not a preview environment (`RENDER==='true' && IS_PULL_REQUEST==='true'` disables it).
 - Routes under `/api` (e.g. `/api/webhook/alert`) are mounted regardless of bot launch; individual features and notification channels are gated via env flags and per-channel validation.
 - API documentation is public and read-only at `/docs` and `/openapi.json`; protected `/api` operations remain guarded by `validateApiKey` and the contract documents both header and legacy query authentication.
+- Alert-producing routes now accept optional per-request notification routing:
+  - `channels` — non-empty array limited to `telegram` and/or `whatsapp`
+  - `telegramChatId` / `whatsappChatId` — optional per-channel destination overrides
+  - If `channels` is omitted, delivery still uses the existing broadcast-to-all-enabled-channels behavior.
 - Stored alert read, export, analytics, and replay routes (`GET /api/alerts`, `GET /api/alerts/export`, `GET /api/alerts/summary`, `GET /api/alerts/:alertId`, `POST /api/alerts/:alertId/replay`) are also mounted under `/api`; they require `WEBHOOK_API_KEY` when configured, return `403 FEATURE_DISABLED` unless `ENABLE_FIRESTORE_ALERT_STORAGE=true`, and return `503 STORAGE_UNAVAILABLE` when Firestore is enabled but unreadable.
 
 ---

--- a/src/controllers/alerts/alerts.js
+++ b/src/controllers/alerts/alerts.js
@@ -16,6 +16,7 @@ const EXPORT_FIELDS = [
 	'source',
 	'enriched',
 	'useTradingViewData',
+	'channels',
 	'deliveryResults',
 	'tokenUsage',
 	'text',

--- a/src/controllers/webhooks/handlers/alert/alert.js
+++ b/src/controllers/webhooks/handlers/alert/alert.js
@@ -9,6 +9,13 @@ const { getURLShortener } = require('../../handlers/newsMonitor/urlShortener');
 const sentryService = require('../../../../services/monitoring/SentryService');
 const { TokenUsageTracker } = require('../../../../lib/tokenUsage');
 const alertStorageService = require('../../../../services/storage/AlertStorageService');
+const {
+	NotificationRoutingValidationError,
+	parseNotificationRouting,
+	sendWithNotificationRouting,
+	getRequestedChannels,
+	getDeliveredChannels,
+} = require('../../../../services/notification/requestRouting');
 
 // Initialize services
 let notificationManager = null;
@@ -117,6 +124,7 @@ function postAlert(botOrGetter) {
 
 		try {
 			const requestSpan = sentryService.getActiveSpan();
+			const routing = parseNotificationRouting(typeof body === 'object' ? body : undefined);
 
 			if (typeof body === 'object' && 'text' in body) {
 				alertText = body.text;
@@ -154,10 +162,19 @@ function postAlert(botOrGetter) {
 			}
 
 			// NotificationManager owns the custom dispatch spans.
-			const results = await notificationManager.sendToAll(alert, { parentSpan: requestSpan });
+			const results = await sendWithNotificationRouting(notificationManager, alert, routing, { parentSpan: requestSpan });
+			const requestedChannels = getRequestedChannels(notificationManager, routing);
+			const deliveredChannels = getDeliveredChannels(results);
 
 			// Return 200 OK regardless of delivery success (fail-open pattern)
-			res.json({ success: true, results, enriched, tokenUsage: tokenUsageJSON });
+			res.json({
+				success: true,
+				results,
+				enriched,
+				tokenUsage: tokenUsageJSON,
+				requestedChannels,
+				deliveredChannels,
+			});
 
 			// Fire-and-forget: persist alert to Firestore after responding to the caller.
 			// Errors are caught inside saveAlert — delivery is never blocked by storage.
@@ -167,9 +184,18 @@ function postAlert(botOrGetter) {
 				enrichmentData: alert.enriched || null,
 				tokenUsage: tokenUsageJSON,
 				deliveryResults: results,
+				channels: requestedChannels,
 				useTradingViewData,
 			}).catch(() => {}); // errors already logged inside AlertStorageService
 		} catch (error) {
+			if (error instanceof NotificationRoutingValidationError) {
+				return res.status(error.statusCode).json({
+					success: false,
+					error: error.message,
+					details: error.details,
+				});
+			}
+
 			console.error('[Alert] Request failed:', error.message);
 
 			// Capture runtime error to Sentry (T012)

--- a/src/controllers/webhooks/handlers/expandedAnalysisAlert/expandedAnalysisAlert.js
+++ b/src/controllers/webhooks/handlers/expandedAnalysisAlert/expandedAnalysisAlert.js
@@ -12,6 +12,13 @@ const {
 	initializeNotificationServices,
 } = require('../alert/alert');
 const sentryService = require('../../../../services/monitoring/SentryService');
+const {
+	NotificationRoutingValidationError,
+	parseNotificationRouting,
+	sendWithNotificationRouting,
+	getRequestedChannels,
+	getDeliveredChannels,
+} = require('../../../../services/notification/requestRouting');
 
 const DEFAULT_ALERT_TIMEOUT_MS = 60000;
 const MAX_ALERT_TIMEOUT_MS = 120000;
@@ -37,6 +44,7 @@ function postExpandedAnalysisAlert(botOrGetter) {
 
 		try {
 			const requestSpan = sentryService.getActiveSpan();
+			const routing = parseNotificationRouting(req.body);
 			const parsed = parseExpandedAnalysisAlertRequest(req);
 			const timeoutMs = getAlertTimeoutMs();
 			const deadline = createAlertDeadline(timeoutMs);
@@ -96,7 +104,9 @@ function postExpandedAnalysisAlert(botOrGetter) {
 				notificationManager = await initializeNotificationServices(resolveBot(botOrGetter));
 			}
 
-			const deliveryResults = await notificationManager.sendToAll({ text: alertText }, { parentSpan: requestSpan });
+			const deliveryResults = await sendWithNotificationRouting(notificationManager, { text: alertText }, routing, { parentSpan: requestSpan });
+			const requestedChannels = getRequestedChannels(notificationManager, routing);
+			const deliveredChannels = getDeliveredChannels(deliveryResults);
 			const summary = buildSummary(results, deliveryResults);
 
 			return res.status(200).json({
@@ -104,6 +114,8 @@ function postExpandedAnalysisAlert(botOrGetter) {
 				alertText,
 				results: compactResults(results),
 				deliveryResults,
+				requestedChannels,
+				deliveredChannels,
 				summary,
 				timedOut,
 				timeoutMs,
@@ -111,6 +123,14 @@ function postExpandedAnalysisAlert(botOrGetter) {
 				totalDurationMs: Date.now() - startTime,
 			});
 		} catch (error) {
+			if (error instanceof NotificationRoutingValidationError) {
+				return res.status(400).json({
+					error: error.message,
+					code: 'INVALID_REQUEST',
+					requestId,
+				});
+			}
+
 			if (error instanceof ExpandedAnalysisAlertRequestError) {
 				return res.status(400).json({
 					error: error.message,

--- a/src/controllers/webhooks/handlers/marketScanner/marketScanner.js
+++ b/src/controllers/webhooks/handlers/marketScanner/marketScanner.js
@@ -12,6 +12,13 @@ const {
 	initializeNotificationServices,
 } = require('../alert/alert');
 const sentryService = require('../../../../services/monitoring/SentryService');
+const {
+	NotificationRoutingValidationError,
+	parseNotificationRouting,
+	sendWithNotificationRouting,
+	getRequestedChannels,
+	getDeliveredChannels,
+} = require('../../../../services/notification/requestRouting');
 
 const DEFAULT_SCANNER_TIMEOUT_MS = 90000;
 const MAX_SCANNER_TIMEOUT_MS = 120000;
@@ -44,6 +51,7 @@ function postMarketScannerAlert(botOrGetter) {
 			}
 
 			const requestSpan = sentryService.getActiveSpan();
+			const routing = parseNotificationRouting(req.body);
 			const parsed = parseMarketScannerRequest(req);
 			const timeoutMs = getMarketScannerTimeoutMs();
 			const deadline = createScannerDeadline(timeoutMs);
@@ -102,7 +110,9 @@ function postMarketScannerAlert(botOrGetter) {
 				notificationManager = await initializeNotificationServices(resolveBot(botOrGetter));
 			}
 
-			const deliveryResults = await notificationManager.sendToAll({ text: alertText }, { parentSpan: requestSpan });
+			const deliveryResults = await sendWithNotificationRouting(notificationManager, { text: alertText }, routing, { parentSpan: requestSpan });
+			const requestedChannels = getRequestedChannels(notificationManager, routing);
+			const deliveredChannels = getDeliveredChannels(deliveryResults);
 			const summary = buildSummary(scanResults, deliveryResults);
 
 			return res.status(200).json({
@@ -110,6 +120,8 @@ function postMarketScannerAlert(botOrGetter) {
 				alertText,
 				scanResults: compactScanResults(scanResults),
 				deliveryResults,
+				requestedChannels,
+				deliveredChannels,
 				summary,
 				timedOut,
 				timeoutMs,
@@ -117,6 +129,14 @@ function postMarketScannerAlert(botOrGetter) {
 				totalDurationMs: Date.now() - startTime,
 			});
 		} catch (error) {
+			if (error instanceof NotificationRoutingValidationError) {
+				return res.status(400).json({
+					error: error.message,
+					code: 'INVALID_REQUEST',
+					requestId,
+				});
+			}
+
 			if (error instanceof MarketScannerRequestError) {
 				return res.status(400).json({
 					error: error.message,

--- a/src/controllers/webhooks/handlers/message/message.js
+++ b/src/controllers/webhooks/handlers/message/message.js
@@ -1,63 +1,33 @@
 require('dotenv').config();
 const sentryService = require('../../../../services/monitoring/SentryService');
 const { getNotificationManager, initializeNotificationServices } = require('../alert/alert');
-
-const VALID_CHANNELS = ['telegram', 'whatsapp'];
+const {
+	VALID_CHANNELS,
+	NotificationRoutingValidationError,
+	parseNotificationRouting,
+	sendWithNotificationRouting,
+} = require('../../../../services/notification/requestRouting');
 const MAX_MESSAGE_LENGTH = 4000;
-
-class MessageValidationError extends Error {
-	constructor(message, details = null) {
-		super(message);
-		this.name = 'MessageValidationError';
-		this.details = details;
-		this.statusCode = 400;
-	}
-}
 
 function validateMessageRequest(body) {
 	if (!body || typeof body !== 'object') {
-		throw new MessageValidationError('Request body must be a JSON object');
+		throw new NotificationRoutingValidationError('Request body must be a JSON object');
 	}
 
-	const { message, channels, telegramChatId, whatsappChatId } = body;
+	const { message } = body;
 
 	if (!message || typeof message !== 'string') {
-		throw new MessageValidationError('"message" is required and must be a non-empty string', {
+		throw new NotificationRoutingValidationError('"message" is required and must be a non-empty string', {
 			field: 'message',
 		});
 	}
-
-	if (!channels || !Array.isArray(channels) || channels.length === 0) {
-		throw new MessageValidationError('"channels" is required and must be a non-empty array', {
-			field: 'channels',
-		});
-	}
-
-	const unknownChannels = channels.filter(ch => !VALID_CHANNELS.includes(ch));
-	if (unknownChannels.length > 0) {
-		throw new MessageValidationError(
-			`Unknown channel(s): ${unknownChannels.join(', ')}. Valid channels: ${VALID_CHANNELS.join(', ')}`,
-			{ field: 'channels', unknownChannels },
-		);
-	}
-
-	if (telegramChatId !== undefined && (typeof telegramChatId !== 'string' || telegramChatId.length === 0)) {
-		throw new MessageValidationError('"telegramChatId" must be a non-empty string if provided', {
-			field: 'telegramChatId',
-		});
-	}
-
-	if (whatsappChatId !== undefined && (typeof whatsappChatId !== 'string' || whatsappChatId.length === 0)) {
-		throw new MessageValidationError('"whatsappChatId" must be a non-empty string if provided', {
-			field: 'whatsappChatId',
-		});
-	}
+	const routing = parseNotificationRouting(body, { requiredChannels: true });
 
 	const text = message.length > MAX_MESSAGE_LENGTH
 		? message.substring(0, MAX_MESSAGE_LENGTH) + '...'
 		: message;
 
-	return { text, channels, telegramChatId, whatsappChatId };
+	return { text, ...routing };
 }
 
 function postMessage(botOrGetter) {
@@ -84,11 +54,11 @@ function postMessage(botOrGetter) {
 				}
 			}
 
-			const results = await notificationManager.sendToChannels(alert, channels);
+			const results = await sendWithNotificationRouting(notificationManager, alert, { channels, telegramChatId, whatsappChatId });
 
 			res.json({ success: true, results });
 		} catch (error) {
-			if (error instanceof MessageValidationError) {
+			if (error instanceof NotificationRoutingValidationError) {
 				return res.status(error.statusCode).json({
 					success: false,
 					error: error.message,
@@ -117,7 +87,7 @@ function postMessage(botOrGetter) {
 
 module.exports = {
 	postMessage,
-	MessageValidationError,
+	MessageValidationError: NotificationRoutingValidationError,
 	VALID_CHANNELS,
 	MAX_MESSAGE_LENGTH,
 };

--- a/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
@@ -39,6 +39,12 @@ function getNotificationManager() {
 	return notificationManager;
 }
 
+function hasExplicitRouting(routing = {}) {
+	return Array.isArray(routing.channels) ||
+		typeof routing.telegramChatId === 'string' ||
+		typeof routing.whatsappChatId === 'string';
+}
+
 class NewsAnalyzer {
 	constructor() {
 		this.cache = getCacheInstance();
@@ -154,10 +160,19 @@ class NewsAnalyzer {
 			const cached = this.cache.get(symbol, category);
 			if (cached) {
 				console.debug('[Analyzer] Returning cached result:', symbol, category);
+				let deliveryResults = cached.deliveryResults;
+				if (cached.alert && hasExplicitRouting(routing)) {
+					const notificationMgr = getNotificationManager();
+					if (notificationMgr) {
+						deliveryResults = await sendWithNotificationRouting(notificationMgr, cached.alert, routing);
+					} else {
+						deliveryResults = [];
+					}
+				}
 				return {
 					status: AnalysisStatus.CACHED,
 					alert: cached.alert,
-					deliveryResults: cached.deliveryResults,
+					deliveryResults,
 					cached: true,
 				};
 			}

--- a/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
@@ -12,7 +12,11 @@ const { AnalysisStatus, EventCategory } = require('./constants');
 const { GROUNDING_MODEL_NAME, ENABLE_NEWS_MONITOR_TEST_MODE } = require('../../../../services/grounding/config');
 const { getPromptService, PromptKeys } = require('../../../../services/prompts');
 const { MainClient } = require('binance');
-const { sendWithNotificationRouting } = require('../../../../services/notification/requestRouting');
+const {
+	sendWithNotificationRouting,
+	getRequestedChannels,
+	getDeliveredChannels,
+} = require('../../../../services/notification/requestRouting');
 
 const promptService = getPromptService();
 
@@ -43,6 +47,25 @@ function hasExplicitRouting(routing = {}) {
 	return Array.isArray(routing.channels) ||
 		typeof routing.telegramChatId === 'string' ||
 		typeof routing.whatsappChatId === 'string';
+}
+
+function shouldRedeliverCachedAlert(notificationMgr, cachedDeliveryResults, routing = {}) {
+	if (!notificationMgr) {
+		return false;
+	}
+
+	if (hasExplicitRouting(routing)) {
+		return true;
+	}
+
+	const requestedChannels = getRequestedChannels(notificationMgr, routing);
+	const deliveredChannels = getDeliveredChannels(cachedDeliveryResults);
+	if (requestedChannels.length !== deliveredChannels.length) {
+		return true;
+	}
+
+	const deliveredSet = new Set(deliveredChannels);
+	return requestedChannels.some((channel) => !deliveredSet.has(channel));
 }
 
 class NewsAnalyzer {
@@ -161,11 +184,11 @@ class NewsAnalyzer {
 			if (cached) {
 				console.debug('[Analyzer] Returning cached result:', symbol, category);
 				let deliveryResults = cached.deliveryResults;
-				if (cached.alert && hasExplicitRouting(routing)) {
+				if (cached.alert) {
 					const notificationMgr = getNotificationManager();
-					if (notificationMgr) {
+					if (shouldRedeliverCachedAlert(notificationMgr, cached.deliveryResults, routing)) {
 						deliveryResults = await sendWithNotificationRouting(notificationMgr, cached.alert, routing);
-					} else {
+					} else if (!notificationMgr) {
 						deliveryResults = [];
 					}
 				}

--- a/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
@@ -68,6 +68,27 @@ function shouldRedeliverCachedAlert(notificationMgr, cachedDeliveryResults, rout
 	return requestedChannels.some((channel) => !deliveredSet.has(channel));
 }
 
+function getCachedRoutingMetadata(routing = {}) {
+	return {
+		channels: Array.isArray(routing.channels) ? [...routing.channels] : undefined,
+		telegramChatId: typeof routing.telegramChatId === 'string' ? routing.telegramChatId : undefined,
+		whatsappChatId: typeof routing.whatsappChatId === 'string' ? routing.whatsappChatId : undefined,
+	};
+}
+
+function cachedOverridesDiffer(cachedRouting = {}, routing = {}) {
+	return cachedRouting.telegramChatId !== (typeof routing.telegramChatId === 'string' ? routing.telegramChatId : undefined)
+		|| cachedRouting.whatsappChatId !== (typeof routing.whatsappChatId === 'string' ? routing.whatsappChatId : undefined);
+}
+
+function shouldRedeliverCachedAlertForRequest(notificationMgr, cachedEntry = {}, routing = {}) {
+	if (cachedOverridesDiffer(cachedEntry.routing, routing)) {
+		return true;
+	}
+
+	return shouldRedeliverCachedAlert(notificationMgr, cachedEntry.deliveryResults, routing);
+}
+
 class NewsAnalyzer {
 	constructor() {
 		this.cache = getCacheInstance();
@@ -186,7 +207,7 @@ class NewsAnalyzer {
 				let deliveryResults = cached.deliveryResults;
 				if (cached.alert) {
 					const notificationMgr = getNotificationManager();
-					if (shouldRedeliverCachedAlert(notificationMgr, cached.deliveryResults, routing)) {
+					if (shouldRedeliverCachedAlertForRequest(notificationMgr, cached, routing)) {
 						deliveryResults = await sendWithNotificationRouting(notificationMgr, cached.alert, routing);
 					} else if (!notificationMgr) {
 						deliveryResults = [];
@@ -289,6 +310,7 @@ class NewsAnalyzer {
 				cached: false,
 				requestId,
 			},
+			routing: getCachedRoutingMetadata(routing),
 			deliveryResults,
 		});
 

--- a/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
@@ -12,6 +12,7 @@ const { AnalysisStatus, EventCategory } = require('./constants');
 const { GROUNDING_MODEL_NAME, ENABLE_NEWS_MONITOR_TEST_MODE } = require('../../../../services/grounding/config');
 const { getPromptService, PromptKeys } = require('../../../../services/prompts');
 const { MainClient } = require('binance');
+const { sendWithNotificationRouting } = require('../../../../services/notification/requestRouting');
 
 const promptService = getPromptService();
 
@@ -57,9 +58,9 @@ class NewsAnalyzer {
    * @param {string} requestId - Correlation ID for tracing
    * @returns {Promise<Object[]>} Array of AnalysisResult objects
    */
-	async analyzeSymbols(symbols, requestId, tokenUsage) {
+	async analyzeSymbols(symbols, requestId, tokenUsage, routing = {}) {
 		const analysisPromises = symbols.map(symbol =>
-			this.analyzeSymbol(symbol, requestId, tokenUsage).catch(error => ({
+			this.analyzeSymbol(symbol, requestId, tokenUsage, routing).catch(error => ({
 				symbol,
 				status: AnalysisStatus.ERROR,
 				error: {
@@ -100,7 +101,7 @@ class NewsAnalyzer {
    * @param {string} requestId - Correlation ID
    * @returns {Promise<Object>} AnalysisResult object
    */
-	async analyzeSymbol(symbol, requestId, tokenUsage) {
+	async analyzeSymbol(symbol, requestId, tokenUsage, routing = {}) {
 		const startTime = Date.now();
 		const analysis = {
 			symbol,
@@ -113,7 +114,7 @@ class NewsAnalyzer {
 		try {
 			// Attempt to run analysis with timeout
 			const result = await Promise.race([
-				this.analyzeSymbolInternal(symbol, requestId, tokenUsage),
+				this.analyzeSymbolInternal(symbol, requestId, tokenUsage, routing),
 				this.timeoutPromise(this.timeout),
 			]);
 
@@ -145,7 +146,7 @@ class NewsAnalyzer {
    * @param {string} requestId - Correlation ID
    * @returns {Promise<Object>} Partial AnalysisResult (status, alert, etc.)
    */
-	async analyzeSymbolInternal(symbol, requestId, tokenUsage) {
+	async analyzeSymbolInternal(symbol, requestId, tokenUsage, routing = {}) {
 		// Try cache first
 		for (const category of Object.values(EventCategory)) {
 			if (category === EventCategory.NONE) continue;
@@ -238,7 +239,7 @@ class NewsAnalyzer {
 				cached: false,
 			};
 		}
-		const deliveryResults = await notificationMgr.sendToAll(alert);
+		const deliveryResults = await sendWithNotificationRouting(notificationMgr, alert, routing);
 		console.info('[Analyzer] Alert delivery results for', symbol, ':', deliveryResults);
 
 		// Cache the result

--- a/src/controllers/webhooks/handlers/newsMonitor/newsMonitor.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/newsMonitor.js
@@ -12,6 +12,12 @@ const { AnalysisStatus } = require('./constants');
 const { getNotificationManager } = require('../alert/alert');
 const sentryService = require('../../../../services/monitoring/SentryService');
 const { TokenUsageTracker } = require('../../../../lib/tokenUsage');
+const {
+	NotificationRoutingValidationError,
+	parseNotificationRouting,
+	getRequestedChannels,
+	getDeliveredChannels,
+} = require('../../../../services/notification/requestRouting');
 
 class NewsMonitorHandler {
 	constructor() {
@@ -58,6 +64,9 @@ class NewsMonitorHandler {
 			}
 
 			// Parse request
+			const routing = req.method === 'GET'
+				? parseNotificationRouting(req.query, { allowQueryChannels: true })
+				: parseNotificationRouting(req.body);
 			const { crypto, stocks } = this.parseRequest(req);
 			const allSymbols = [...(crypto || []), ...(stocks || [])];
 			const validationError = this.validateRequest(allSymbols);
@@ -96,17 +105,20 @@ class NewsMonitorHandler {
 
 			let results;
 			try {
-				results = await this.analyzer.analyzeSymbols(symbolsToAnalyze, requestId, tokenUsage);
+				results = await this.analyzer.analyzeSymbols(symbolsToAnalyze, requestId, tokenUsage, routing);
 			} finally {
 				sentryService.endSpan(analysisSpan);
 			}
 
 			const summary = this.generateSummary(results);
+			const notificationManagerForResponse = getNotificationManager();
 			const response = {
 				success: summary.analyzed > 0 || summary.cached > 0,
 				partial_success: summary.timeout > 0 || summary.error > 0,
 				results,
 				summary,
+				requestedChannels: getRequestedChannels(notificationManagerForResponse, routing),
+				deliveredChannels: getDeliveredChannels(results.flatMap((result) => result.deliveryResults || [])),
 				totalDurationMs: Date.now() - startTime,
 				requestId,
 				tokenUsage: tokenUsage.toJSON(),
@@ -124,6 +136,14 @@ class NewsMonitorHandler {
 
 			return res.status(200).json(response);
 		} catch (error) {
+			if (error instanceof NotificationRoutingValidationError) {
+				return res.status(400).json({
+					error: error.message,
+					code: 'INVALID_REQUEST',
+					requestId,
+				});
+			}
+
 			console.error('[NewsMonitor] Unexpected error:', error);
 
 			// Capture runtime error to Sentry (T013) - only for 500 errors

--- a/src/controllers/webhooks/handlers/scannerPresets/scannerPresets.js
+++ b/src/controllers/webhooks/handlers/scannerPresets/scannerPresets.js
@@ -14,6 +14,13 @@ const {
 	initializeNotificationServices,
 } = require('../alert/alert');
 const sentryService = require('../../../../services/monitoring/SentryService');
+const {
+	NotificationRoutingValidationError,
+	parseNotificationRouting,
+	sendWithNotificationRouting,
+	getRequestedChannels,
+	getDeliveredChannels,
+} = require('../../../../services/notification/requestRouting');
 
 const DEFAULT_SCANNER_TIMEOUT_MS = 90000;
 const MAX_SCANNER_TIMEOUT_MS = 120000;
@@ -144,6 +151,7 @@ function listPresets(req, res) {
 function getPreset(req, res) {
 	return (async () => {
 		try {
+			const routing = parseNotificationRouting(req.body);
 			const preset = await scannerPresetService.getPreset(req.params.id);
 			if (!preset) {
 				return res.status(404).json({
@@ -252,6 +260,7 @@ function postRunPreset(botOrGetter) {
 					code: 'FEATURE_DISABLED',
 				});
 			}
+			const routing = parseNotificationRouting(req.body);
 
 			const preset = await scannerPresetService.getPreset(req.params.id);
 			if (!preset) {
@@ -318,9 +327,11 @@ function postRunPreset(botOrGetter) {
 				notificationManager = await initializeNotificationServices(resolveBot(botOrGetter));
 			}
 
-			const deliveryResults = await notificationManager.sendToAll({ text: alertText }, {
+			const deliveryResults = await sendWithNotificationRouting(notificationManager, { text: alertText }, routing, {
 				parentSpan: sentryService.getActiveSpan(),
 			});
+			const requestedChannels = getRequestedChannels(notificationManager, routing);
+			const deliveredChannels = getDeliveredChannels(deliveryResults);
 			const summary = buildSummary(scanResults, deliveryResults);
 
 			return res.status(200).json({
@@ -329,6 +340,8 @@ function postRunPreset(botOrGetter) {
 				alertText,
 				scanResults: compactScanResults(scanResults),
 				deliveryResults,
+				requestedChannels,
+				deliveredChannels,
 				summary,
 				timedOut,
 				timeoutMs,
@@ -336,6 +349,14 @@ function postRunPreset(botOrGetter) {
 				totalDurationMs: Date.now() - startTime,
 			});
 		} catch (error) {
+			if (error instanceof NotificationRoutingValidationError) {
+				return res.status(400).json({
+					error: error.message,
+					code: 'INVALID_REQUEST',
+					requestId,
+				});
+			}
+
 			console.error('[ScannerPresets] Run failed:', error.message);
 			sentryService.captureRuntimeError({
 				channel: 'scanner-presets',

--- a/src/openapi/openapi.json
+++ b/src/openapi/openapi.json
@@ -237,15 +237,15 @@
       "StockSymbols": { "name": "stocks", "in": "query", "schema": { "type": "string" }, "example": "NVDA,MSFT" }
     },
     "requestBodies": {
-      "Alert": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AlertRequest" }, "example": { "text": "BTCUSDT broke resistance with strong volume" } }, "text/plain": { "schema": { "type": "string" }, "example": "BTCUSDT broke resistance" } } },
+      "Alert": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AlertRequest" }, "example": { "text": "BTCUSDT broke resistance with strong volume", "channels": ["telegram"], "telegramChatId": "-1001234567890" } }, "text/plain": { "schema": { "type": "string" }, "example": "BTCUSDT broke resistance" } } },
       "Message": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/MessageRequest" }, "example": { "message": "Deployment completed", "channels": ["telegram", "whatsapp"] } } } },
-      "ExpandedAnalysis": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ExpandedAnalysisRequest" }, "example": { "symbols": ["BINANCE:BTCUSDT", "NASDAQ:NVDA"], "timeframe": "1D", "analysisMode": "standard", "includeMultiTimeframe": false } } } },
-      "MarketScanner": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/MarketScannerRequest" }, "example": { "exchange": "BINANCE", "timeframe": "4h", "scans": ["top_gainers", "top_losers", "volume_breakout_scanner"], "limit": 5 } } } },
+      "ExpandedAnalysis": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ExpandedAnalysisRequest" }, "example": { "symbols": ["BINANCE:BTCUSDT", "NASDAQ:NVDA"], "timeframe": "1D", "analysisMode": "standard", "includeMultiTimeframe": false, "channels": ["telegram"], "telegramChatId": "-1001234567890" } } } },
+      "MarketScanner": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/MarketScannerRequest" }, "example": { "exchange": "BINANCE", "timeframe": "4h", "scans": ["top_gainers", "top_losers", "volume_breakout_scanner"], "limit": 5, "channels": ["telegram"] } } } },
       "VolumeConfirmation": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/VolumeConfirmationRequest" }, "example": { "symbol": "BINANCE:BTCUSDT", "timeframe": "1h" } } } },
       "Replay": { "content": { "application/json": { "schema": { "type": "object", "properties": { "channels": { "type": "array", "items": { "type": "string", "enum": ["telegram", "whatsapp"] } } } }, "example": { "channels": ["telegram"] } } } },
       "ScannerPreset": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ScannerPresetRequest" }, "example": { "name": "Daily Scan", "exchange": "BINANCE", "timeframe": "4h", "scans": ["top_gainers"], "limit": 5 } } } },
-      "TradingViewJob": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/TradingViewJobRequest" }, "examples": { "expandedAnalysis": { "value": { "type": "expanded-analysis", "symbols": ["BINANCE:BTCUSDT"], "timeframe": "1D" } }, "marketScanner": { "value": { "type": "market-scanner", "exchange": "BINANCE", "timeframe": "4h" } } } } } },
-      "NewsMonitor": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/NewsMonitorRequest" }, "example": { "crypto": ["BTCUSDT", "ETHUSD"], "stocks": ["NVDA"] } } } }
+      "TradingViewJob": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/TradingViewJobRequest" }, "examples": { "expandedAnalysis": { "value": { "type": "expanded-analysis", "symbols": ["BINANCE:BTCUSDT"], "timeframe": "1D", "channels": ["telegram"], "telegramChatId": "-1001234567890" } }, "marketScanner": { "value": { "type": "market-scanner", "exchange": "BINANCE", "timeframe": "4h", "channels": ["telegram"] } } } } } },
+      "NewsMonitor": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/NewsMonitorRequest" }, "example": { "crypto": ["BTCUSDT", "ETHUSD"], "stocks": ["NVDA"], "channels": ["telegram"] } } } }
     },
     "responses": {
       "Unauthorized": { "description": "API key rejected", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" }, "example": { "error": "Unauthorized", "code": "UNAUTHORIZED" } } } },
@@ -260,9 +260,9 @@
     "schemas": {
       "JsonObject": { "type": "object", "additionalProperties": true },
       "Error": { "type": "object", "required": ["error"], "properties": { "error": { "type": "string" }, "code": { "type": "string" } } },
-      "AlertRequest": { "type": "object", "required": ["text"], "properties": { "text": { "type": "string", "minLength": 1 } } },
+      "AlertRequest": { "type": "object", "required": ["text"], "properties": { "text": { "type": "string", "minLength": 1 }, "channels": { "type": "array", "minItems": 1, "items": { "type": "string", "enum": ["telegram", "whatsapp"] } }, "telegramChatId": { "type": "string", "minLength": 1 }, "whatsappChatId": { "type": "string", "minLength": 1 } } },
       "MessageRequest": { "type": "object", "required": ["message", "channels"], "properties": { "message": { "type": "string", "minLength": 1 }, "channels": { "type": "array", "minItems": 1, "items": { "type": "string", "enum": ["telegram", "whatsapp"] } }, "telegramChatId": { "type": "string", "minLength": 1 }, "whatsappChatId": { "type": "string", "minLength": 1 } } },
-      "ExpandedAnalysisRequest": { "type": "object", "properties": { "symbols": { "type": "array", "maxItems": 50, "items": { "type": "string", "pattern": "^[A-Z0-9_]+:[A-Z0-9._-]+$" } }, "timeframe": { "type": "string", "enum": ["5m", "15m", "1h", "4h", "1D", "1W", "1M"] }, "analysisMode": { "type": "string", "enum": ["standard", "combined"], "default": "standard" }, "includeMultiTimeframe": { "type": "boolean", "default": false } } },
+      "ExpandedAnalysisRequest": { "type": "object", "properties": { "symbols": { "type": "array", "maxItems": 50, "items": { "type": "string", "pattern": "^[A-Z0-9_]+:[A-Z0-9._-]+$" } }, "timeframe": { "type": "string", "enum": ["5m", "15m", "1h", "4h", "1D", "1W", "1M"] }, "analysisMode": { "type": "string", "enum": ["standard", "combined"], "default": "standard" }, "includeMultiTimeframe": { "type": "boolean", "default": false }, "channels": { "type": "array", "minItems": 1, "items": { "type": "string", "enum": ["telegram", "whatsapp"] } }, "telegramChatId": { "type": "string", "minLength": 1 }, "whatsappChatId": { "type": "string", "minLength": 1 } } },
       "MarketScannerRequest": {
         "type": "object",
         "properties": {
@@ -270,14 +270,17 @@
           "timeframe": { "type": "string", "default": "4h" },
           "scans": { "type": "array", "items": { "type": "string", "enum": ["top_gainers", "top_losers", "volume_breakout_scanner", "smart_volume_scanner", "bollinger_scan"] } },
           "limit": { "type": "integer", "minimum": 1, "maximum": 20, "default": 5 },
-          "bbw_threshold": { "type": "number", "default": 0.05 }
+          "bbw_threshold": { "type": "number", "default": 0.05 },
+          "channels": { "type": "array", "minItems": 1, "items": { "type": "string", "enum": ["telegram", "whatsapp"] } },
+          "telegramChatId": { "type": "string", "minLength": 1 },
+          "whatsappChatId": { "type": "string", "minLength": 1 }
         }
       },
       "VolumeConfirmationRequest": { "type": "object", "required": ["symbol"], "properties": { "symbol": { "type": "string", "pattern": "^[A-Z0-9_]+:[A-Z0-9._-]+$" }, "timeframe": { "type": "string" } } },
       "ScannerPresetRequest": { "type": "object", "required": ["name"], "properties": { "name": { "type": "string", "minLength": 1 }, "exchange": { "type": "string" }, "timeframe": { "type": "string" }, "scans": { "type": "array", "items": { "type": "string" } }, "limit": { "type": "integer", "minimum": 1, "maximum": 20 }, "bbw_threshold": { "type": "number" } } },
       "TradingViewJobRequest": { "oneOf": [{ "allOf": [{ "type": "object", "required": ["type"], "properties": { "type": { "const": "expanded-analysis" } } }, { "$ref": "#/components/schemas/ExpandedAnalysisRequest" }] }, { "allOf": [{ "type": "object", "required": ["type"], "properties": { "type": { "const": "market-scanner" } } }, { "$ref": "#/components/schemas/MarketScannerRequest" }] }] },
-      "NewsMonitorRequest": { "type": "object", "properties": { "crypto": { "type": "array", "items": { "type": "string" } }, "stocks": { "type": "array", "items": { "type": "string" } } } },
-      "DeliveryResult": { "type": "object", "properties": { "success": { "type": "boolean" }, "results": { "type": "array", "items": { "type": "object", "properties": { "channel": { "type": "string" }, "success": { "type": "boolean" }, "error": { "type": "string" } } } }, "enriched": { "type": "boolean" }, "tokenUsage": { "$ref": "#/components/schemas/JsonObject" } } },
+      "NewsMonitorRequest": { "type": "object", "properties": { "crypto": { "type": "array", "items": { "type": "string" } }, "stocks": { "type": "array", "items": { "type": "string" } }, "channels": { "type": "array", "minItems": 1, "items": { "type": "string", "enum": ["telegram", "whatsapp"] } }, "telegramChatId": { "type": "string", "minLength": 1 }, "whatsappChatId": { "type": "string", "minLength": 1 } } },
+      "DeliveryResult": { "type": "object", "properties": { "success": { "type": "boolean" }, "results": { "type": "array", "items": { "type": "object", "properties": { "channel": { "type": "string" }, "success": { "type": "boolean" }, "error": { "type": "string" } } } }, "enriched": { "type": "boolean" }, "tokenUsage": { "$ref": "#/components/schemas/JsonObject" }, "requestedChannels": { "type": "array", "items": { "type": "string" } }, "deliveredChannels": { "type": "array", "items": { "type": "string" } } } },
       "Job": { "type": "object", "properties": { "success": { "type": "boolean" }, "jobId": { "type": "string", "format": "uuid" }, "status": { "type": "string", "enum": ["pending", "processing", "completed", "failed", "canceled"] }, "progress": { "$ref": "#/components/schemas/JsonObject" }, "result": { "$ref": "#/components/schemas/JsonObject" } } },
       "Status": { "type": "object", "properties": { "service": { "$ref": "#/components/schemas/JsonObject" }, "featureFlags": { "$ref": "#/components/schemas/JsonObject" }, "deliveryChannels": { "$ref": "#/components/schemas/JsonObject" }, "dependencies": { "$ref": "#/components/schemas/JsonObject" } } }
     }

--- a/src/services/jobs/JobService.js
+++ b/src/services/jobs/JobService.js
@@ -17,6 +17,12 @@ const {
 } = require('../../controllers/webhooks/handlers/alert/alert');
 const sentryService = require('../monitoring/SentryService');
 const { jobRepository } = require('./JobRepository');
+const {
+	parseNotificationRouting,
+	sendWithNotificationRouting,
+	getRequestedChannels,
+	getDeliveredChannels,
+} = require('../notification/requestRouting');
 
 const EXPIRATION_MS = 3600000; // 1 hour
 const DEFAULT_JOB_TIMEOUT_MS = 300000; // 5 minutes
@@ -115,9 +121,16 @@ class JobService {
 			formatted.scanResults = this._compactScanResults(job.fullScanResults);
 		}
 
+		if (Array.isArray(job.requestedChannels)) {
+			formatted.requestedChannels = job.requestedChannels;
+		} else if (job.requestMetadata && Array.isArray(job.requestMetadata.channels)) {
+			formatted.requestedChannels = job.requestMetadata.channels;
+		}
+
 		if (job.status === 'completed') {
 			formatted.alertText = job.alertText;
 			formatted.deliveryResults = job.deliveryResults;
+			formatted.deliveredChannels = getDeliveredChannels(job.deliveryResults);
 			formatted.summary = job.summary;
 		} else if (job.status === 'failed') {
 			formatted.error = job.error;
@@ -141,6 +154,7 @@ class JobService {
 	 */
 	async createJob(type, payload, botOrGetter) {
 		await this._cleanExpiredJobs();
+		const routing = parseNotificationRouting(payload);
 
 		// Synchronous validation based on job type
 		let parsed;
@@ -244,6 +258,9 @@ class JobService {
 			callbackUrl,
 			callbackSecret,
 			callbackEvents,
+			...(routing.channels ? { channels: routing.channels } : {}),
+			...(routing.telegramChatId ? { telegramChatId: routing.telegramChatId } : {}),
+			...(routing.whatsappChatId ? { whatsappChatId: routing.whatsappChatId } : {}),
 			...(type === 'expanded-analysis' ? {
 				symbols: parsed.symbols.map((s) => s.raw),
 				timeframe: parsed.timeframe,
@@ -502,8 +519,10 @@ class JobService {
 			notificationManager = await initializeNotificationServices(this._resolveBot(botOrGetter));
 		}
 
-		const deliveryResults = await notificationManager.sendToAll({ text: alertText });
+		const routing = this._getRoutingFromJob(job);
+		const deliveryResults = await sendWithNotificationRouting(notificationManager, { text: alertText }, routing);
 		job.deliveryResults = deliveryResults;
+		job.requestedChannels = getRequestedChannels(notificationManager, routing);
 		job.summary = this._buildExpandedSummary(job.fullResults, deliveryResults);
 		job.status = 'completed';
 		await this._persistJob(job);
@@ -603,8 +622,10 @@ class JobService {
 			notificationManager = await initializeNotificationServices(this._resolveBot(botOrGetter));
 		}
 
-		const deliveryResults = await notificationManager.sendToAll({ text: alertText });
+		const routing = this._getRoutingFromJob(job);
+		const deliveryResults = await sendWithNotificationRouting(notificationManager, { text: alertText }, routing);
 		job.deliveryResults = deliveryResults;
+		job.requestedChannels = getRequestedChannels(notificationManager, routing);
 		job.summary = this._buildScannerSummary(job.fullScanResults, deliveryResults);
 		job.status = 'completed';
 		await this._persistJob(job);
@@ -619,6 +640,15 @@ class JobService {
 			}
 		}
 		await this.repository.save(job);
+	}
+
+	_getRoutingFromJob(job) {
+		const metadata = job && job.requestMetadata ? job.requestMetadata : {};
+		return {
+			channels: metadata.channels,
+			telegramChatId: metadata.telegramChatId,
+			whatsappChatId: metadata.whatsappChatId,
+		};
 	}
 
 	_buildScanArgs(parsed, scanType) {

--- a/src/services/notification/requestRouting.js
+++ b/src/services/notification/requestRouting.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const VALID_CHANNELS = ['telegram', 'whatsapp'];
+
+class NotificationRoutingValidationError extends Error {
+	constructor(message, details = null) {
+		super(message);
+		this.name = 'NotificationRoutingValidationError';
+		this.details = details;
+		this.statusCode = 400;
+	}
+}
+
+function normalizeChannels(rawChannels, options = {}) {
+	const {
+		required = false,
+		allowCsvString = false,
+	} = options;
+
+	if (rawChannels === undefined) {
+		if (required) {
+			throw new NotificationRoutingValidationError('"channels" is required and must be a non-empty array', {
+				field: 'channels',
+			});
+		}
+		return undefined;
+	}
+
+	let channels = rawChannels;
+	if (allowCsvString && typeof rawChannels === 'string') {
+		channels = rawChannels
+			.split(',')
+			.map((channel) => channel.trim())
+			.filter(Boolean);
+	}
+
+	if (!Array.isArray(channels) || channels.length === 0) {
+		throw new NotificationRoutingValidationError('"channels" must be a non-empty array', {
+			field: 'channels',
+		});
+	}
+
+	const uniqueChannels = Array.from(new Set(channels));
+	const unknownChannels = uniqueChannels.filter((channel) => !VALID_CHANNELS.includes(channel));
+	if (unknownChannels.length > 0) {
+		throw new NotificationRoutingValidationError(
+			`Unknown channel(s): ${unknownChannels.join(', ')}. Valid channels: ${VALID_CHANNELS.join(', ')}`,
+			{ field: 'channels', unknownChannels },
+		);
+	}
+
+	return uniqueChannels;
+}
+
+function validateChatOverride(field, value) {
+	if (value === undefined) {
+		return undefined;
+	}
+
+	if (typeof value !== 'string' || value.length === 0) {
+		throw new NotificationRoutingValidationError(`"${field}" must be a non-empty string if provided`, {
+			field,
+		});
+	}
+
+	return value;
+}
+
+function parseNotificationRouting(raw = {}, options = {}) {
+	const {
+		requiredChannels = false,
+		allowQueryChannels = false,
+	} = options;
+
+	if (!raw || typeof raw !== 'object') {
+		if (requiredChannels) {
+			throw new NotificationRoutingValidationError('Request body must be a JSON object');
+		}
+		return {
+			channels: undefined,
+			telegramChatId: undefined,
+			whatsappChatId: undefined,
+		};
+	}
+
+	return {
+		channels: normalizeChannels(raw.channels, {
+			required: requiredChannels,
+			allowCsvString: allowQueryChannels,
+		}),
+		telegramChatId: validateChatOverride('telegramChatId', raw.telegramChatId),
+		whatsappChatId: validateChatOverride('whatsappChatId', raw.whatsappChatId),
+	};
+}
+
+async function sendWithNotificationRouting(notificationManager, alert, routing = {}, options = {}) {
+	const alertPayload = {
+		...alert,
+		telegramChatId: routing.telegramChatId,
+		whatsappChatId: routing.whatsappChatId,
+	};
+
+	if (routing.channels) {
+		return notificationManager.sendToChannels(alertPayload, routing.channels, options);
+	}
+
+	return notificationManager.sendToAll(alertPayload, options);
+}
+
+function getRequestedChannels(notificationManager, routing = {}) {
+	if (routing.channels) {
+		return routing.channels;
+	}
+
+	if (!notificationManager || typeof notificationManager.getEnabledChannels !== 'function') {
+		return [];
+	}
+
+	return notificationManager.getEnabledChannels();
+}
+
+function getDeliveredChannels(results = []) {
+	return results
+		.filter((result) => result && result.success)
+		.map((result) => result.channel);
+}
+
+module.exports = {
+	VALID_CHANNELS,
+	NotificationRoutingValidationError,
+	parseNotificationRouting,
+	sendWithNotificationRouting,
+	getRequestedChannels,
+	getDeliveredChannels,
+};

--- a/src/services/storage/AlertStorageService.js
+++ b/src/services/storage/AlertStorageService.js
@@ -77,6 +77,7 @@ function formatAlertDocument(doc) {
 		enriched: Boolean(data.enriched),
 		enrichmentData: data.enrichmentData || null,
 		tokenUsage: data.tokenUsage || null,
+		channels: Array.isArray(data.channels) ? data.channels : [],
 		deliveryResults: Array.isArray(data.deliveryResults) ? data.deliveryResults : [],
 		source: typeof data.source === 'string' ? data.source : null,
 		useTradingViewData: Boolean(data.useTradingViewData),
@@ -401,11 +402,12 @@ function getFirestore() {
  * @param {boolean} params.enriched          - Whether enrichment ran
  * @param {Object|null} params.enrichmentData - alert.enriched object or null
  * @param {Object|null} params.tokenUsage    - tokenUsage.toJSON() result or null
+ * @param {Array<string>} params.channels    - Requested channels used for delivery
  * @param {Array}   params.deliveryResults   - Array of SendResult from notificationManager.sendToAll()
  * @param {boolean} params.useTradingViewData - Whether ?useTradingViewData=true was set on the request
  * @returns {Promise<string|null>} The new Firestore document ID, or null on failure/disabled
  */
-async function saveAlert({ text, enriched, enrichmentData, tokenUsage, deliveryResults, useTradingViewData }) {
+async function saveAlert({ text, enriched, enrichmentData, tokenUsage, channels, deliveryResults, useTradingViewData }) {
 	const firestore = getFirestore();
 	if (!firestore) {
 		return null;
@@ -418,6 +420,7 @@ async function saveAlert({ text, enriched, enrichmentData, tokenUsage, deliveryR
 			enriched: Boolean(enriched),
 			enrichmentData: enrichmentData || null,
 			tokenUsage: tokenUsage || null,
+			channels: Array.isArray(channels) ? channels : [],
 			deliveryResults: Array.isArray(deliveryResults) ? deliveryResults : [],
 			source: 'webhook',
 			useTradingViewData: Boolean(useTradingViewData),

--- a/tests/integration/alert-grounding.test.js
+++ b/tests/integration/alert-grounding.test.js
@@ -271,5 +271,54 @@ describe('Alert Grounding Integration', () => {
 			expect(telegramResult).toBeDefined();
 			expect(telegramResult.success).toBe(true);
 		});
+
+		it('routes alert delivery to requested channels only and reports requested channels', async () => {
+			process.env.ENABLE_GEMINI_GROUNDING = 'false';
+			process.env.ENABLE_WHATSAPP_ALERTS = 'true';
+			process.env.WHATSAPP_API_URL = 'https://api.greenapi.com/waInstance123/';
+			process.env.WHATSAPP_API_KEY = 'test-whatsapp-key';
+			process.env.WHATSAPP_CHAT_ID = '120363000000000000@g.us';
+
+			const response = await request(app)
+				.post('/api/webhook/alert').set('x-api-key', 'test-key')
+				.send({
+					text: 'Route this only to telegram',
+					channels: ['telegram'],
+					telegramChatId: '-100999888777',
+				})
+				.expect(200);
+
+			expect(response.body.success).toBe(true);
+			expect(response.body.requestedChannels).toEqual(['telegram']);
+			expect(response.body.deliveredChannels).toEqual(['telegram']);
+			expect(response.body.results).toHaveLength(1);
+			expect(response.body.results[0]).toEqual(expect.objectContaining({
+				channel: 'telegram',
+				success: true,
+			}));
+			expect(mockTelegramSendMessage).toHaveBeenCalledWith(
+				'-100999888777',
+				expect.any(String),
+				expect.any(Object),
+			);
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
+
+		it('returns 400 when alert webhook receives an unsupported channel name', async () => {
+			process.env.ENABLE_GEMINI_GROUNDING = 'false';
+
+			const response = await request(app)
+				.post('/api/webhook/alert').set('x-api-key', 'test-key')
+				.send({
+					text: 'Bad channel request',
+					channels: ['telegram', 'discord'],
+				})
+				.expect(400);
+
+			expect(response.body.error).toContain('Unknown channel');
+			expect(response.body.error).toContain('discord');
+			expect(mockTelegramSendMessage).not.toHaveBeenCalled();
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/tests/integration/alerts-endpoint.test.js
+++ b/tests/integration/alerts-endpoint.test.js
@@ -408,7 +408,7 @@ describe('Alerts API Integration Tests', () => {
 			includeText: true,
 		});
 		expect(res.headers['content-type']).toContain('text/csv');
-		expect(res.text).toContain('id,receivedAt,source,enriched,useTradingViewData,deliveryResults,tokenUsage,text');
+		expect(res.text).toContain('id,receivedAt,source,enriched,useTradingViewData,channels,deliveryResults,tokenUsage,text');
 		expect(res.text).toContain('"BTC, breakout"');
 		expect(res.text).toContain('PROVIDER_LIMIT');
 	});

--- a/tests/integration/expanded-analysis-alert-endpoint.test.js
+++ b/tests/integration/expanded-analysis-alert-endpoint.test.js
@@ -16,6 +16,7 @@ describe('Expanded Analysis Alert endpoint', () => {
 	const originalEnv = process.env;
 	let mockTelegramSendMessage;
 	let mockBot;
+	let mockFetch;
 
 	beforeEach(async () => {
 		process.env = {
@@ -39,6 +40,12 @@ describe('Expanded Analysis Alert endpoint', () => {
 			},
 		};
 
+		mockFetch = jest.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ idMessage: 'wa-msg-456' }),
+		});
+		global.fetch = mockFetch;
+
 		await initializeNotificationServices(mockBot);
 		app.use('/api', getRoutes(mockBot));
 	});
@@ -48,6 +55,7 @@ describe('Expanded Analysis Alert endpoint', () => {
 		if (app._router && app._router.stack && app._router.stack.length > 0) {
 			app._router.stack.pop();
 		}
+		delete global.fetch;
 	});
 
 	it('generates an expanded analysis report, sends it, and returns delivery results', async () => {
@@ -92,6 +100,48 @@ describe('Expanded Analysis Alert endpoint', () => {
 		}));
 		expect(mockTelegramSendMessage).toHaveBeenCalledTimes(1);
 		expect(mockTelegramSendMessage.mock.calls[0][1]).toContain('ANÁLISIS AMPLIADO');
+	});
+
+	it('routes expanded analysis delivery to requested channels only', async () => {
+		process.env.ENABLE_WHATSAPP_ALERTS = 'true';
+		process.env.WHATSAPP_API_URL = 'https://api.greenapi.com/waInstance123/';
+		process.env.WHATSAPP_API_KEY = 'test-whatsapp-key';
+		process.env.WHATSAPP_CHAT_ID = '120363000000000000@g.us';
+
+		tradingViewMcpService.analyzeSymbolIdentifier.mockResolvedValueOnce({
+			symbol: 'NASDAQ:NVDA',
+			price_data: {
+				current_price: 219.51,
+				change_percent: -1.8,
+			},
+			technical_indicators: {
+				rsi: 57.8,
+				sma20: 214.1,
+				macd: 6.1,
+				macd_signal: 7.2,
+			},
+		});
+
+		const res = await request(app)
+			.post('/api/webhook/expanded-analysis-alert')
+			.set('x-api-key', 'test-key')
+			.send({
+				symbols: ['NASDAQ:NVDA'],
+				timeframe: '1D',
+				channels: ['telegram'],
+				telegramChatId: '-100999888777',
+			})
+			.expect(200);
+
+		expect(res.body.requestedChannels).toEqual(['telegram']);
+		expect(res.body.deliveredChannels).toEqual(['telegram']);
+		expect(res.body.deliveryResults).toHaveLength(1);
+		expect(mockTelegramSendMessage).toHaveBeenCalledWith(
+			'-100999888777',
+			expect.any(String),
+			expect.any(Object),
+		);
+		expect(mockFetch).not.toHaveBeenCalled();
 	});
 
 	it('returns 504 when the expanded analysis alert deadline expires before analysis completes', async () => {

--- a/tests/integration/jobs-endpoint.test.js
+++ b/tests/integration/jobs-endpoint.test.js
@@ -17,6 +17,7 @@ describe('Jobs API Integration Tests', () => {
 	const originalEnv = process.env;
 	let mockTelegramSendMessage;
 	let mockBot;
+	let mockFetch;
 
 	beforeEach(async () => {
 		process.env = {
@@ -39,6 +40,12 @@ describe('Jobs API Integration Tests', () => {
 			},
 		};
 
+		mockFetch = jest.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ idMessage: 'wa-msg-456' }),
+		});
+		global.fetch = mockFetch;
+
 		await initializeNotificationServices(mockBot);
 		app.use('/api', getRoutes(mockBot));
 	});
@@ -48,6 +55,7 @@ describe('Jobs API Integration Tests', () => {
 		if (app._router && app._router.stack && app._router.stack.length > 0) {
 			app._router.stack.pop();
 		}
+		delete global.fetch;
 	});
 
 	it('returns 401 when POST /api/jobs/tradingview-analysis lacks valid api key', async () => {
@@ -121,6 +129,57 @@ describe('Jobs API Integration Tests', () => {
 		expect(statusRes.body.deliveryResults).toEqual([
 			expect.objectContaining({ success: true, channel: 'telegram', messageId: 'job-msg-id' }),
 		]);
+	});
+
+	it('routes async job delivery to requested channels only', async () => {
+		process.env.ENABLE_WHATSAPP_ALERTS = 'true';
+		process.env.WHATSAPP_API_URL = 'https://api.greenapi.com/waInstance123/';
+		process.env.WHATSAPP_API_KEY = 'test-whatsapp-key';
+		process.env.WHATSAPP_CHAT_ID = '120363000000000000@g.us';
+
+		tradingViewMcpService.analyzeSymbolIdentifier.mockResolvedValueOnce({
+			symbol: 'BINANCE:BTCUSDT',
+			price_data: { close: 65000, change_percent: 1.5 },
+			rsi: { value: 45 },
+		});
+
+		const createRes = await request(app)
+			.post('/api/jobs/tradingview-analysis')
+			.set('x-api-key', 'test-key')
+			.send({
+				type: 'expanded-analysis',
+				symbols: ['BINANCE:BTCUSDT'],
+				channels: ['telegram'],
+				telegramChatId: '-100999888777',
+			})
+			.expect(201);
+
+		const jobId = createRes.body.jobId;
+		let statusRes = await request(app)
+			.get(`/api/jobs/${jobId}`)
+			.set('x-api-key', 'test-key')
+			.expect(200);
+
+		let attempts = 0;
+		while (statusRes.body.status !== 'completed' && attempts < 10) {
+			await new Promise((resolve) => setTimeout(resolve, 30));
+			statusRes = await request(app)
+				.get(`/api/jobs/${jobId}`)
+				.set('x-api-key', 'test-key')
+				.expect(200);
+			attempts++;
+		}
+
+		expect(statusRes.body.status).toBe('completed');
+		expect(statusRes.body.requestedChannels).toEqual(['telegram']);
+		expect(statusRes.body.deliveredChannels).toEqual(['telegram']);
+		expect(statusRes.body.deliveryResults).toHaveLength(1);
+		expect(mockTelegramSendMessage).toHaveBeenCalledWith(
+			'-100999888777',
+			expect.any(String),
+			expect.any(Object),
+		);
+		expect(mockFetch).not.toHaveBeenCalled();
 	});
 
 	it('returns 404 for non-existent job ID', async () => {

--- a/tests/integration/market-scanner-endpoint.test.js
+++ b/tests/integration/market-scanner-endpoint.test.js
@@ -14,6 +14,7 @@ describe('Market Scanner Alert endpoint', () => {
 	const originalEnv = process.env;
 	let mockTelegramSendMessage;
 	let mockBot;
+	let mockFetch;
 
 	beforeEach(async () => {
 		process.env = {
@@ -36,6 +37,12 @@ describe('Market Scanner Alert endpoint', () => {
 			},
 		};
 
+		mockFetch = jest.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ idMessage: 'wa-msg-456' }),
+		});
+		global.fetch = mockFetch;
+
 		await initializeNotificationServices(mockBot);
 		app.use('/api', getRoutes(mockBot));
 	});
@@ -45,6 +52,7 @@ describe('Market Scanner Alert endpoint', () => {
 		if (app._router && app._router.stack && app._router.stack.length > 0) {
 			app._router.stack.pop();
 		}
+		delete global.fetch;
 	});
 
 	it('returns 401 when request lacks valid api key', async () => {
@@ -92,6 +100,43 @@ describe('Market Scanner Alert endpoint', () => {
 		);
 		expect(mockTelegramSendMessage).toHaveBeenCalledTimes(1);
 		expect(mockTelegramSendMessage.mock.calls[0][1]).toContain('SCANNER DE MERCADO');
+	});
+
+	it('routes market scanner delivery to requested channels only', async () => {
+		process.env.ENABLE_WHATSAPP_ALERTS = 'true';
+		process.env.WHATSAPP_API_URL = 'https://api.greenapi.com/waInstance123/';
+		process.env.WHATSAPP_API_KEY = 'test-whatsapp-key';
+		process.env.WHATSAPP_CHAT_ID = '120363000000000000@g.us';
+
+		tradingViewMcpService.callScanTool.mockResolvedValueOnce([
+			{
+				symbol: 'BINANCE:GMTUSDT',
+				changePercent: 26.415,
+				indicators: { close: 0.0134, RSI: 79.72 },
+			},
+		]);
+
+		const res = await request(app)
+			.post('/api/webhook/market-scanner-alert')
+			.set('x-api-key', 'test-key')
+			.send({
+				scans: ['top_gainers'],
+				timeframe: '4h',
+				exchange: 'BINANCE',
+				channels: ['telegram'],
+				telegramChatId: '-100999888777',
+			})
+			.expect(200);
+
+		expect(res.body.requestedChannels).toEqual(['telegram']);
+		expect(res.body.deliveredChannels).toEqual(['telegram']);
+		expect(res.body.deliveryResults).toHaveLength(1);
+		expect(mockTelegramSendMessage).toHaveBeenCalledWith(
+			'-100999888777',
+			expect.any(String),
+			expect.any(Object),
+		);
+		expect(mockFetch).not.toHaveBeenCalled();
 	});
 
 	it('returns 502 when all scanner calls fail', async () => {

--- a/tests/integration/news-monitor-basic.test.js
+++ b/tests/integration/news-monitor-basic.test.js
@@ -2,6 +2,7 @@ const request = require('supertest');
 const app = require('../../app');
 const { getRoutes } = require('../../src/routes');
 const { initializeNotificationServices } = require('../../src/controllers/webhooks/handlers/alert/alert');
+const { getCacheInstance } = require('../../src/controllers/webhooks/handlers/newsMonitor/cache');
 
 jest.mock('../../src/services/grounding/gemini');
 jest.mock('../../src/services/grounding/genaiClient');
@@ -18,8 +19,12 @@ describe('News Monitor - Basic Endpoint Integration', () => {
 			ENABLE_NEWS_MONITOR: 'true',
 			NODE_ENV: 'test',
 			ENABLE_TELEGRAM_BOT: 'true',
+			ENABLE_WHATSAPP_ALERTS: 'true',
 			BOT_TOKEN: 'test-token',
 			TELEGRAM_CHAT_ID: '123456789',
+			WHATSAPP_API_URL: 'https://api.greenapi.com/waInstance123/',
+			WHATSAPP_API_KEY: 'test-whatsapp-key',
+			WHATSAPP_CHAT_ID: '120363000000000000@g.us',
 			RENDER: '',
 			IS_PULL_REQUEST: '',
 			GEMINI_API_KEY: 'test-key',
@@ -28,6 +33,7 @@ describe('News Monitor - Basic Endpoint Integration', () => {
 		};
 
 		jest.clearAllMocks();
+		getCacheInstance().clear();
 
 		// Mock Gemini for symbol analysis
 		const gemini = require('../../src/services/grounding/gemini');
@@ -61,6 +67,7 @@ describe('News Monitor - Basic Endpoint Integration', () => {
 		mockBot = {
 			telegram: {
 				sendMessage: mockTelegramSendMessage,
+				getMe: jest.fn().mockResolvedValue({ id: 123456789, username: 'TestBot' }),
 			},
 		};
 
@@ -208,6 +215,20 @@ describe('News Monitor - Basic Endpoint Integration', () => {
 				.expect(200);
 
 			expect(res.body).toHaveProperty('success');
+		});
+
+		it('should route alerts to requested channels only', async () => {
+			const res = await request(app)
+				.post('/api/news-monitor').set('x-api-key', 'test-key')
+				.send({
+					crypto: ['ROUTEBTC'],
+					channels: ['telegram'],
+					telegramChatId: '-100999888777',
+				})
+				.expect(200);
+
+			expect(res.body.requestedChannels).toEqual(['telegram']);
+			expect(global.fetch).not.toHaveBeenCalled();
 		});
 	});
 

--- a/tests/integration/news-monitor-cache.test.js
+++ b/tests/integration/news-monitor-cache.test.js
@@ -15,6 +15,7 @@ jest.mock('../../src/services/grounding/genaiClient');
 describe('News Monitor - Cache Deduplication (US3)', () => {
 	const originalEnv = process.env;
 	let mockBot;
+	let mockFetch;
 
 	beforeEach(async () => {
 		process.env = {
@@ -23,8 +24,12 @@ describe('News Monitor - Cache Deduplication (US3)', () => {
 			ENABLE_NEWS_MONITOR: 'true',
 			NODE_ENV: 'test',
 			ENABLE_TELEGRAM_BOT: 'true',
+			ENABLE_WHATSAPP_ALERTS: 'true',
 			BOT_TOKEN: 'test-token',
 			TELEGRAM_CHAT_ID: '123456789',
+			WHATSAPP_API_URL: 'https://api.greenapi.com/waInstance123/',
+			WHATSAPP_API_KEY: 'test-whatsapp-key',
+			WHATSAPP_CHAT_ID: '120363000000000000@g.us',
 			RENDER: '',
 			IS_PULL_REQUEST: '',
 			GEMINI_API_KEY: 'test-key',
@@ -50,8 +55,15 @@ describe('News Monitor - Cache Deduplication (US3)', () => {
 		mockBot = {
 			telegram: {
 				sendMessage: jest.fn().mockResolvedValue({ message_id: 'test-message-id' }),
+				getMe: jest.fn().mockResolvedValue({ id: 123456789, username: 'TestBot' }),
 			},
 		};
+
+		mockFetch = jest.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ idMessage: 'wa-msg-456' }),
+		});
+		global.fetch = mockFetch;
 
 		// Initialize notification services
 		await initializeNotificationServices(mockBot);
@@ -78,6 +90,7 @@ describe('News Monitor - Cache Deduplication (US3)', () => {
 		// Give async handlers time to complete
 		setImmediate(() => {
 			jest.clearAllMocks();
+			delete global.fetch;
 			done();
 		});
 	});
@@ -185,6 +198,44 @@ describe('News Monitor - Cache Deduplication (US3)', () => {
 	});
 
 	describe('Cache Deduplication Impact', () => {
+		it('should re-deliver cached alerts when a later request asks for different channels', async () => {
+			const response1 = await request(app)
+				.post('/api/news-monitor').set('x-api-key', 'test-key')
+				.send({
+					crypto: ['BTCUSDT'],
+					channels: ['whatsapp'],
+				})
+				.expect(200);
+
+			expect(response1.body.results[0].cached).toBe(false);
+			expect(response1.body.requestedChannels).toEqual(['whatsapp']);
+			expect(response1.body.deliveredChannels).toEqual(['whatsapp']);
+			expect(mockBot.telegram.sendMessage).not.toHaveBeenCalled();
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+
+			const response2 = await request(app)
+				.post('/api/news-monitor').set('x-api-key', 'test-key')
+				.send({
+					crypto: ['BTCUSDT'],
+					channels: ['telegram'],
+					telegramChatId: '-100999888777',
+				})
+				.expect(200);
+
+			expect(response2.body.results[0].cached).toBe(true);
+			expect(response2.body.requestedChannels).toEqual(['telegram']);
+			expect(response2.body.deliveredChannels).toEqual(['telegram']);
+			expect(response2.body.results[0].deliveryResults).toEqual([
+				expect.objectContaining({ channel: 'telegram', success: true }),
+			]);
+			expect(mockBot.telegram.sendMessage).toHaveBeenCalledWith(
+				'-100999888777',
+				expect.any(String),
+				expect.any(Object),
+			);
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+		});
+
 		it('should include cached alerts in response', async () => {
 			// First call
 			const response1 = await request(app)

--- a/tests/integration/news-monitor-cache.test.js
+++ b/tests/integration/news-monitor-cache.test.js
@@ -236,6 +236,41 @@ describe('News Monitor - Cache Deduplication (US3)', () => {
 			expect(mockFetch).toHaveBeenCalledTimes(1);
 		});
 
+		it('should re-deliver cached alerts to all enabled channels when a later request omits channels', async () => {
+			const response1 = await request(app)
+				.post('/api/news-monitor').set('x-api-key', 'test-key')
+				.send({
+					crypto: ['BTCUSDT'],
+					channels: ['whatsapp'],
+				})
+				.expect(200);
+
+			expect(response1.body.results[0].cached).toBe(false);
+			expect(response1.body.requestedChannels).toEqual(['whatsapp']);
+			expect(response1.body.deliveredChannels).toEqual(['whatsapp']);
+			expect(mockBot.telegram.sendMessage).not.toHaveBeenCalled();
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+
+			const response2 = await request(app)
+				.post('/api/news-monitor').set('x-api-key', 'test-key')
+				.send({
+					crypto: ['BTCUSDT'],
+				})
+				.expect(200);
+
+			expect(response2.body.results[0].cached).toBe(true);
+			expect(response2.body.requestedChannels).toEqual(['telegram', 'whatsapp']);
+			expect(response2.body.deliveredChannels).toEqual(['telegram', 'whatsapp']);
+			expect(response2.body.results[0].deliveryResults).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ channel: 'telegram', success: true }),
+					expect.objectContaining({ channel: 'whatsapp', success: true }),
+				]),
+			);
+			expect(mockBot.telegram.sendMessage).toHaveBeenCalledTimes(1);
+			expect(mockFetch).toHaveBeenCalledTimes(2);
+		});
+
 		it('should include cached alerts in response', async () => {
 			// First call
 			const response1 = await request(app)

--- a/tests/integration/news-monitor-cache.test.js
+++ b/tests/integration/news-monitor-cache.test.js
@@ -271,6 +271,44 @@ describe('News Monitor - Cache Deduplication (US3)', () => {
 			expect(mockFetch).toHaveBeenCalledTimes(2);
 		});
 
+		it('should re-deliver cached alerts to the default destination when the cached send used a chat override', async () => {
+			const response1 = await request(app)
+				.post('/api/news-monitor').set('x-api-key', 'test-key')
+				.send({
+					crypto: ['BTCUSDT'],
+					channels: ['telegram'],
+					telegramChatId: '-100999888777',
+				})
+				.expect(200);
+
+			expect(response1.body.results[0].cached).toBe(false);
+			expect(response1.body.requestedChannels).toEqual(['telegram']);
+			expect(response1.body.deliveredChannels).toEqual(['telegram']);
+			expect(mockBot.telegram.sendMessage).toHaveBeenCalledWith(
+				'-100999888777',
+				expect.any(String),
+				expect.any(Object),
+			);
+
+			const response2 = await request(app)
+				.post('/api/news-monitor').set('x-api-key', 'test-key')
+				.send({
+					crypto: ['BTCUSDT'],
+				})
+				.expect(200);
+
+			expect(response2.body.results[0].cached).toBe(true);
+			expect(response2.body.requestedChannels).toEqual(['telegram', 'whatsapp']);
+			expect(response2.body.deliveredChannels).toEqual(['telegram', 'whatsapp']);
+			expect(mockBot.telegram.sendMessage).toHaveBeenLastCalledWith(
+				'123456789',
+				expect.any(String),
+				expect.any(Object),
+			);
+			expect(mockBot.telegram.sendMessage).toHaveBeenCalledTimes(2);
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+		});
+
 		it('should include cached alerts in response', async () => {
 			// First call
 			const response1 = await request(app)

--- a/tests/integration/scanner-presets-endpoint.test.js
+++ b/tests/integration/scanner-presets-endpoint.test.js
@@ -10,13 +10,17 @@ const admin = require('firebase-admin');
 const request = require('supertest');
 const app = require('../../app');
 const { getRoutes } = require('../../src/routes');
+const { initializeNotificationServices } = require('../../src/controllers/webhooks/handlers/alert/alert');
 const { tradingViewMcpService } = require('../../src/services/tradingview/TradingViewMcpService');
 const { _resetForTesting: resetScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
 
 describe('Scanner presets API integration tests', () => {
 	const originalEnv = process.env;
+	let mockBot;
+	let mockTelegramSendMessage;
+	let mockFetch;
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		process.env = {
 			...originalEnv,
 			WEBHOOK_API_KEY: 'test-key',
@@ -25,12 +29,30 @@ describe('Scanner presets API integration tests', () => {
 			ENABLE_NEWS_MONITOR: 'false',
 			MARKET_SCANNER_TIMEOUT_MS: '1000',
 			TRADINGVIEW_MCP_DEFAULT_TIMEFRAME: '4h',
+			ENABLE_TELEGRAM_BOT: 'true',
+			BOT_TOKEN: 'test-bot-token',
+			TELEGRAM_CHAT_ID: '123456789',
+			ENABLE_WHATSAPP_ALERTS: 'false',
 		};
 
 		jest.clearAllMocks();
 		admin.__resetCollectionState();
 		resetScannerPresetService();
-		app.use('/api', getRoutes(null));
+		mockTelegramSendMessage = jest.fn().mockResolvedValue({ message_id: 'preset-msg-id' });
+		mockBot = {
+			telegram: {
+				sendMessage: mockTelegramSendMessage,
+				getMe: jest.fn().mockResolvedValue({ id: 123456789, username: 'TestBot' }),
+			},
+		};
+		mockFetch = jest.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ idMessage: 'wa-msg-456' }),
+		});
+		global.fetch = mockFetch;
+
+		await initializeNotificationServices(mockBot);
+		app.use('/api', getRoutes(mockBot));
 	});
 
 	afterEach(() => {
@@ -38,6 +60,7 @@ describe('Scanner presets API integration tests', () => {
 		if (app._router && app._router.stack && app._router.stack.length > 0) {
 			app._router.stack.pop();
 		}
+		delete global.fetch;
 	});
 
 	it('creates, updates, lists, retrieves, and deletes saved presets', async () => {
@@ -159,5 +182,55 @@ describe('Scanner presets API integration tests', () => {
 			{ exchange: 'BINANCE', timeframe: '4h', limit: 5 },
 			expect.any(Object),
 		);
+	});
+
+	it('routes preset delivery to requested channels only', async () => {
+		process.env.ENABLE_TELEGRAM_BOT = 'true';
+		process.env.BOT_TOKEN = 'test-bot-token';
+		process.env.TELEGRAM_CHAT_ID = '123456789';
+		process.env.ENABLE_WHATSAPP_ALERTS = 'true';
+		process.env.WHATSAPP_API_URL = 'https://api.greenapi.com/waInstance123/';
+		process.env.WHATSAPP_API_KEY = 'test-whatsapp-key';
+		process.env.WHATSAPP_CHAT_ID = '120363000000000000@g.us';
+
+		tradingViewMcpService.callScanTool.mockResolvedValueOnce([
+			{
+				symbol: 'BINANCE:GMTUSDT',
+				changePercent: 26.415,
+				indicators: { close: 0.0134, RSI: 79.72 },
+			},
+		]);
+
+		const createResponse = await request(app)
+			.post('/api/scanner-presets')
+			.set('x-api-key', 'test-key')
+			.send({
+				name: 'Telegram preset',
+				exchange: 'binance',
+				timeframe: '4h',
+				scans: ['top_gainers'],
+			})
+			.expect(201);
+
+		const presetId = createResponse.body.preset.id;
+
+		const runResponse = await request(app)
+			.post(`/api/scanner-presets/${presetId}/run`)
+			.set('x-api-key', 'test-key')
+			.send({
+				channels: ['telegram'],
+				telegramChatId: '-100999888777',
+			})
+			.expect(200);
+
+		expect(runResponse.body.requestedChannels).toEqual(['telegram']);
+		expect(runResponse.body.deliveredChannels).toEqual(['telegram']);
+		expect(runResponse.body.deliveryResults).toHaveLength(1);
+		expect(mockTelegramSendMessage).toHaveBeenCalledWith(
+			'-100999888777',
+			expect.any(String),
+			expect.any(Object),
+		);
+		expect(mockFetch).not.toHaveBeenCalled();
 	});
 });

--- a/tests/unit/alert-storage-service.test.js
+++ b/tests/unit/alert-storage-service.test.js
@@ -176,6 +176,7 @@ describe('AlertStorageService', () => {
 					{ channel: 'telegram', success: true },
 					{ channel: 'whatsapp', success: false },
 				],
+				channels: ['telegram'],
 				useTradingViewData: true,
 			});
 
@@ -193,9 +194,23 @@ describe('AlertStorageService', () => {
 					{ channel: 'telegram', success: true },
 					{ channel: 'whatsapp', success: false },
 				],
+				channels: ['telegram'],
 				source: 'webhook',
 				useTradingViewData: true,
 			});
+		});
+
+		it('persists requested channels for stored alert exports and replays', async () => {
+			process.env.ENABLE_FIRESTORE_ALERT_STORAGE = 'true';
+			mockAdd.mockResolvedValueOnce({ id: 'id-channels' });
+
+			await AlertStorageService.saveAlert(buildParams({
+				channels: ['telegram'],
+				deliveryResults: [{ channel: 'telegram', success: true }],
+			}));
+
+			const calledWith = mockAdd.mock.calls[0][0];
+			expect(calledWith.channels).toEqual(['telegram']);
 		});
 
 		it('truncates text longer than 20000 characters', async () => {
@@ -296,6 +311,7 @@ describe('AlertStorageService', () => {
 						enriched: true,
 						enrichmentData: { sentiment: 'bullish' },
 						tokenUsage: { totalTokens: 42 },
+						channels: ['telegram'],
 						deliveryResults: [{ channel: 'telegram', success: true }],
 						source: 'webhook',
 						useTradingViewData: false,
@@ -328,6 +344,7 @@ describe('AlertStorageService', () => {
 					enriched: true,
 					enrichmentData: { sentiment: 'bullish' },
 					tokenUsage: { totalTokens: 42 },
+					channels: ['telegram'],
 					deliveryResults: [{ channel: 'telegram', success: true }],
 					source: 'webhook',
 					useTradingViewData: false,
@@ -493,6 +510,7 @@ describe('AlertStorageService', () => {
 				enriched: false,
 				enrichmentData: null,
 				tokenUsage: null,
+				channels: ['telegram'],
 				deliveryResults: [{ channel: 'telegram', success: true }],
 				source: 'webhook',
 				useTradingViewData: true,
@@ -507,6 +525,7 @@ describe('AlertStorageService', () => {
 				enriched: false,
 				enrichmentData: null,
 				tokenUsage: null,
+				channels: ['telegram'],
 				deliveryResults: [{ channel: 'telegram', success: true }],
 				source: 'webhook',
 				useTradingViewData: true,


### PR DESCRIPTION
## Summary

feat(webhooks): add channel routing (CB-32)

Add optional per-request notification routing to alert-producing flows so callers can target Telegram and WhatsApp selectively, override destination chat IDs, and still preserve the existing broadcast behavior when no explicit channel list is provided.

## Key Changes

### :satellite: Shared routing contract

- Added a shared notification-routing helper that validates `channels`, `telegramChatId`, and `whatsappChatId`.
- Reused the same routing logic across generic messages, alert webhooks, expanded analysis, market scanner, scanner presets, news monitor, and async TradingView jobs.
- Kept fail-open delivery semantics for downstream providers while failing fast on invalid channel requests.

### :package: Alert-producing endpoint coverage

- Updated alert-producing handlers to dispatch through `sendToChannels(...)` when requested and `sendToAll(...)` otherwise.
- Added `requestedChannels` and `deliveredChannels` to API responses for delivery observability.
- Persisted requested channel metadata for async job responses and stored alert flows where applicable.

### :memo: Contract and docs updates

- Extended OpenAPI schemas and request examples with optional channel-routing fields.
- Updated the Postman collection with route-specific request samples using targeted delivery.
- Added agent-facing documentation describing the shared routing behavior and compatibility rules.

## Technical Implementation

### Architecture changes

#### `src/services/notification/requestRouting.js`

Centralizes request validation and dispatch selection for optional channel targeting, avoiding duplicated handler-specific parsing logic.

#### `src/services/jobs/JobService.js`

Carries routing metadata through async job creation and completion so background deliveries respect the requested channel subset and expose it in status responses.

### File Structure Additions

```text
src/services/notification/
└── requestRouting.js    # Shared per-request channel-routing validation and dispatch helper
```

## Testing infraestructure

### Test Suite

- **699 total automated tests passing**
- **Focused integration coverage added for alert, expanded analysis, market scanner, scanner presets, jobs, and news monitor routing**

### Test Coverage

- Added positive and negative coverage for explicit channel selection and invalid channel rejection.
- Verified async jobs and scanner preset executions preserve requested channel routing.
- Confirmed legacy message webhook behavior still works after the shared validation refactor.

## Documentation Updates

- **OpenAPI contract** Added optional `channels`, `telegramChatId`, and `whatsappChatId` fields to alert-producing request schemas and examples.
- **Postman collection** Added targeted-delivery request examples for webhook, preset, news-monitor, and async job flows.
- **Agent guidance** Documented the shared routing contract and backward-compatible fallback behavior.

## Examples

```json
{
  "text": "BTCUSDT breakout confirmed",
  "channels": ["telegram"],
  "telegramChatId": "-1001234567890"
}
```

```json
{
  "type": "expanded-analysis",
  "symbols": ["BINANCE:BTCUSDT"],
  "timeframe": "1D",
  "channels": ["telegram"]
}
```

## Testing

### Pre-merge Verification

- [ ] Confirm targeted Telegram-only delivery works in a deployed preview
- [ ] Confirm invalid channel names return `400 INVALID_REQUEST`
- [ ] Confirm omitting `channels` still broadcasts to all enabled channels

## References

- **Linear**: [CB-32](https://linear.app/knil/issue/CB-32/support-channel-targeting-on-alert-producing-webhooks)
- **GitHub**: Closes [#102](https://github.com/francovp/cabros-bot/issues/102)

---

**Review Checklist:**

- [ ] Code quality meets project standards
- [ ] All tests pass and coverage is maintained
- [ ] Documentation is complete and accurate
- [ ] Breaking change assessment completed
