### PR TITLE
fix(sentry): gate debug route (CB-37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Express + Telegraf-based Telegram bot service with multi-channel alert delivery 
 - `SENTRY_SAMPLE_RATE_ERRORS` - Error sample rate from 0.0 to 1.0 (default: `1.0` = 100%)
 - `SENTRY_TRACES_SAMPLE_RATE` - Trace sample rate from 0.0 to 1.0 (leave unset to disable tracing and custom spans)
 - `SENTRY_CONSOLE_LOG_LEVELS` - Comma-separated console levels sent as Sentry Logs (default: `warn,error`; allowed: `debug`, `info`, `warn`, `error`, `log`, `assert`, `trace`)
+- `ENABLE_SENTRY_DEBUG_ROUTE` - Mount `GET /debug-sentry` only for explicit local/manual validation (`true` enables it; default disabled so normal runtime returns `404`)
 - Sentry Logs are enabled automatically when `ENABLE_SENTRY=true`; configured console levels are sent as Sentry Logs.
 
 #### TradingView Market Scanner Alerts
@@ -1170,6 +1171,12 @@ SENTRY_CONSOLE_LOG_LEVELS=warn,error
 2. Confirm Sentry initialized with `enableLogs: true`
 3. Confirm `SENTRY_CONSOLE_LOG_LEVELS` includes the level you are testing
 4. Check the Sentry Logs view, not only the Issues view
+
+**Manual Sentry error validation**:
+1. Keep `ENABLE_SENTRY_DEBUG_ROUTE` unset in production and preview environments
+2. For local-only validation, start the app with `ENABLE_SENTRY_DEBUG_ROUTE=true`
+3. Request `GET /debug-sentry` locally to trigger the intentional test error
+4. Remove the flag again after validation so the route falls back to `404`
 
 **Expected behaviors not reporting** (by design):
 - Validation errors (400 responses) are not reported

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const app = require('./app.js');
 const { Telegraf, Markup } = require('telegraf');
 const { getRoutes } = require('./src/routes');
 const { initializeNotificationServices } = require('./src/controllers/webhooks/handlers/alert/alert');
+const { registerDebugSentryRoute } = require('./src/lib/debugSentryRoute');
 const Sentry = require('@sentry/node');
 
 const token = process.env.BOT_TOKEN;
@@ -28,9 +29,7 @@ const now = new Date();
 // Always mount routes (they gate access based on feature flags)
 app.use('/api', getRoutes(() => bot));
 
-app.get('/debug-sentry', function mainHandler() {
-	throw new Error('Sentry debug test error!');
-});
+registerDebugSentryRoute(app);
 
 // The error handler must be registered before any other error middleware and after all controllers
 Sentry.setupExpressErrorHandler(app);

--- a/src/lib/debugSentryRoute.js
+++ b/src/lib/debugSentryRoute.js
@@ -1,0 +1,13 @@
+function registerDebugSentryRoute(app) {
+	if (process.env.ENABLE_SENTRY_DEBUG_ROUTE !== 'true') {
+		return;
+	}
+
+	app.get('/debug-sentry', function mainHandler() {
+		throw new Error('Sentry debug test error!');
+	});
+}
+
+module.exports = {
+	registerDebugSentryRoute,
+};

--- a/tests/unit/debug-sentry-route.test.js
+++ b/tests/unit/debug-sentry-route.test.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const request = require('supertest');
+
+const { registerDebugSentryRoute } = require('../../src/lib/debugSentryRoute');
+
+function createApp() {
+	const app = express();
+
+	registerDebugSentryRoute(app);
+
+	app.use((err, req, res, next) => {
+		res.status(500).json({ message: err.message });
+	});
+
+	return app;
+}
+
+describe('registerDebugSentryRoute', () => {
+	const originalEnv = process.env;
+
+	beforeEach(() => {
+		process.env = { ...originalEnv };
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+	});
+
+	it('returns 404 by default when the debug route is disabled', async () => {
+		delete process.env.ENABLE_SENTRY_DEBUG_ROUTE;
+		const app = createApp();
+
+		const response = await request(app).get('/debug-sentry').expect(404);
+
+		expect(response.status).toBe(404);
+	});
+
+	it('mounts the debug route only when explicitly enabled', async () => {
+		process.env.ENABLE_SENTRY_DEBUG_ROUTE = 'true';
+		const app = createApp();
+
+		const response = await request(app).get('/debug-sentry').expect(500);
+
+		expect(response.body).toEqual({ message: 'Sentry debug test error!' });
+	});
+});


### PR DESCRIPTION
## fix(sentry): gate debug route

## Summary

Gate the public `/debug-sentry` route behind an explicit `ENABLE_SENTRY_DEBUG_ROUTE=true` flag so normal runtime, preview, and production deployments do not expose a forced-error endpoint by default.

## Key Changes

### :lock: Runtime hardening

- Extracts debug-route registration into `src/lib/debugSentryRoute.js`
- Mounts `GET /debug-sentry` only when `ENABLE_SENTRY_DEBUG_ROUTE=true`
- Leaves the route absent by default so requests fall through to `404`

### :test_tube: Regression coverage

- Adds focused unit coverage for the disabled and explicitly enabled route behavior
- Verifies the enabled debug route still throws the intentional Sentry test error

### :memo: Local validation docs

- Documents `ENABLE_SENTRY_DEBUG_ROUTE` in the Sentry runtime configuration section
- Adds a local/manual Sentry validation workflow to `README.md`

## Technical Implementation

### Architecture changes

#### `debugSentryRoute`

This helper centralizes the route-gating logic so `index.js` only delegates registration and the behavior can be tested independently from the full bot bootstrap.

```js
function registerDebugSentryRoute(app) {
  if (process.env.ENABLE_SENTRY_DEBUG_ROUTE !== 'true') {
    return;
  }

  app.get('/debug-sentry', function mainHandler() {
    throw new Error('Sentry debug test error!');
  });
}
```

### File Structure Additions

```text
src/lib/debugSentryRoute.js          # Conditional registration for the Sentry debug route
tests/unit/debug-sentry-route.test.js # Regression coverage for default 404 and explicit enablement
```

## Testing infraestructure

### Test Coverage

- Added route-gating unit coverage for `/debug-sentry`
- Re-ran the full Jest suite after the change

## Documentation Updates

- **Sentry debug route flag** Documents the local-only `ENABLE_SENTRY_DEBUG_ROUTE` workflow and default-disabled runtime behavior

## Testing

### Pre-merge Verification

- [x] `pnpm test -- tests/unit/debug-sentry-route.test.js --runInBand`
- [x] `pnpm test`
- [ ] `pnpm lint` global repo run is still blocked by pre-existing unrelated ESLint errors outside this diff

## References

- GitHub Issue: https://github.com/francovp/cabros-bot/issues/123
- Linear: https://linear.app/knil/issue/CB-37/gate-debug-sentry-route-behind-env-flag

---

**Review Checklist:**

- [ ] Code quality meets project standards
- [ ] All tests pass and coverage is maintained
- [ ] Documentation is complete and accurate
- [ ] Breaking change assessment completed
