### PR TITLE
feat(news): calibrate confidence with source quality and freshness (CB-40)

### DIFF
--- a/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
@@ -616,6 +616,11 @@ class NewsAnalyzer {
 			? enrichmentMetadata.enriched_confidence
 			: geminiAnalysis.confidence;
 
+		// Use geminiAnalysis confidence_reason unless enrichment provides its own
+		const confidenceReason = enrichmentMetadata && enrichmentMetadata.confidence_reason
+			? enrichmentMetadata.confidence_reason
+			: (geminiAnalysis.confidence_reason || '');
+
 		// Build the title/original text
 		const eventLabel = this.eventCategoryLabel(geminiAnalysis.event_category);
 		const headline = (geminiAnalysis.headline && geminiAnalysis.headline.trim())
@@ -658,11 +663,14 @@ class NewsAnalyzer {
 		}
 
 		// Build enriched object for formatEnriched methods
+		const enrichedExtraText = confidenceReason
+			? `_Model Confidence: ${confidense}%_\n_Reason: ${confidenceReason}_\n_Model used: ${GROUNDING_MODEL_NAME}_`
+			: `_Model Confidence: ${confidense}%_\n_Model used: ${GROUNDING_MODEL_NAME}_`;
 		const enriched = {
 			originalText: alertTitle,
 			summary: context,
 			citations,
-			extraText: `_Model Confidence: ${confidense}%_\n_Model used: ${GROUNDING_MODEL_NAME}_`,
+			extraText: enrichedExtraText,
 			tokenUsage: tokenUsageSummary || undefined,
 		};
 
@@ -672,6 +680,7 @@ class NewsAnalyzer {
 			headline: geminiAnalysis.headline,
 			sentimentScore: geminiAnalysis.sentiment_score,
 			confidence: finalConfidence,
+			confidence_reason: confidenceReason,
 			sources: geminiAnalysis.sources,
 			text: alertTitle,
 			enriched,
@@ -708,6 +717,10 @@ class NewsAnalyzer {
 
 		const confidence = analysis.confidence ?? 0;
 		message += `Confidence: ${(confidence * 100).toFixed(0)}%\n`;
+		const reason = analysis.confidence_reason || '';
+		if (reason) {
+			message += `Reason: ${reason}\n`;
+		}
 
 		if (marketContext && marketContext.price) {
 			const change = marketContext.change24h ?? 0;

--- a/src/services/grounding/gemini.js
+++ b/src/services/grounding/gemini.js
@@ -217,14 +217,16 @@ async function analyzeNewsForSymbol(symbol, context, options = {}) {
 		// Use grounded sources if available (store full SearchResult objects, not just URLs)
 		analysisResult.sources = searchResult.results || [];
 
-		// Calculate confidence using formula: (0.6 × event_significance + 0.4 × |sentiment|)
-		const confidence = 0.6 * analysisResult.event_significance + 0.4 * Math.abs(analysisResult.sentiment_score);
-		analysisResult.confidence = Math.max(0, Math.min(1, confidence)); // Clamp to [0, 1]
+		// Calculate calibrated confidence with source metadata penalties
+		const { confidence, confidence_reason } = calibrateNewsConfidence(analysisResult);
+		analysisResult.confidence = confidence;
+		analysisResult.confidence_reason = confidence_reason;
 
 		console.info('[Gemini] News analysis complete with grounding', {
 			symbol,
 			category: analysisResult.event_category,
 			confidence: analysisResult.confidence,
+			confidence_reason: analysisResult.confidence_reason,
 			groundedSources: analysisResult.sources.length,
 		});
 
@@ -255,13 +257,48 @@ function parseNewsAnalysisResponse(response) {
 			throw new Error(`Invalid event_category: ${parsed.event_category}`);
 		}
 
-		// Clamp numeric values
+		// Parse source metadata with defaults and clamping
+		const sourceCount = Number.isFinite(parsed.source_count)
+			? Math.max(0, Math.min(10, Math.round(parsed.source_count)))
+			: 0;
+
+		const sourceFreshness = Number.isFinite(parsed.source_freshness)
+			? Math.max(0, Math.min(1, parsed.source_freshness))
+			: 0.5;
+
+		const sourceQuality = Number.isFinite(parsed.source_quality)
+			? Math.max(0, Math.min(1, parsed.source_quality))
+			: 0.5;
+
+		const eventAgeHours = Number.isFinite(parsed.event_age_hours)
+			? Math.max(0, parsed.event_age_hours)
+			: null;
+
+		const timeHorizon = ['very_short_term', 'short_term', 'medium_term', 'long_term'].includes(parsed.time_horizon)
+			? parsed.time_horizon
+			: 'short_term';
+
+		const uncertaintyReason = typeof parsed.uncertainty_reason === 'string'
+			? parsed.uncertainty_reason.trim()
+			: '';
+
+		const invalidationHint = typeof parsed.invalidation_hint === 'string'
+			? parsed.invalidation_hint.trim()
+			: '';
+
 		return {
 			event_category: parsed.event_category,
 			event_significance: Math.max(0, Math.min(1, parsed.event_significance || 0)),
 			sentiment_score: Math.max(-1, Math.min(1, parsed.sentiment_score || 0)),
 			headline: (parsed.headline || 'Market event detected').substring(0, 250),
 			description: parsed.description || '',
+			source_count: sourceCount,
+			source_freshness: sourceFreshness,
+			source_quality: sourceQuality,
+			event_age_hours: eventAgeHours,
+			time_horizon: timeHorizon,
+			uncertainty_reason: uncertaintyReason,
+			invalidation_hint: invalidationHint,
 		};
 	} catch (error) {
 		console.error('[Gemini] Response parsing failed:', error.message);
@@ -272,8 +309,76 @@ function parseNewsAnalysisResponse(response) {
 			sentiment_score: 0,
 			headline: 'Could not detect market event',
 			description: '',
+			source_count: 0,
+			source_freshness: 0,
+			source_quality: 0,
+			event_age_hours: null,
+			time_horizon: 'short_term',
+			uncertainty_reason: 'parse error',
+			invalidation_hint: '',
 		};
 	}
+}
+
+/**
+ * Calculate calibrated confidence from news analysis result
+ * Applies penalties for limited sources, stale or low-quality sources, and uncertainty
+ * @param {Object} analysisResult - Parsed and validated news analysis result
+ * @returns {{ confidence: number, confidence_reason: string }} Calibrated confidence and reason
+ */
+function calibrateNewsConfidence(analysisResult) {
+	const { event_significance, sentiment_score, source_count, source_freshness, source_quality, uncertainty_reason, invalidation_hint } = analysisResult;
+
+	// Base confidence from significance and sentiment
+	const baseConfidence = 0.6 * event_significance + 0.4 * Math.abs(sentiment_score);
+
+	// Apply penalties
+	const reasons = [];
+	let penalty = 0;
+
+	// Source count penalty: penalize when fewer than 2 sources
+	if (source_count === 0) {
+		penalty += 0.3;
+		reasons.push('no corroborating sources');
+	} else if (source_count === 1) {
+		penalty += 0.15;
+		reasons.push('single source only');
+	}
+
+	// Source freshness penalty: penalize stale sources
+	if (source_freshness < 0.3) {
+		penalty += 0.15;
+		reasons.push('sources appear stale');
+	} else if (source_freshness < 0.6) {
+		penalty += 0.08;
+		reasons.push('moderate source freshness');
+	}
+
+	// Source quality penalty: penalize low-quality/unreliable domains
+	if (source_quality < 0.3) {
+		penalty += 0.2;
+		reasons.push('low source authority');
+	} else if (source_quality < 0.6) {
+		penalty += 0.1;
+		reasons.push('moderate source authority');
+	}
+
+	// Uncertainty penalty
+	if (uncertainty_reason && uncertainty_reason.length > 0) {
+		penalty += 0.1;
+		reasons.push(`uncertain: ${uncertainty_reason}`);
+	}
+
+	// Invalidation hint penalty
+	if (invalidation_hint && invalidation_hint.length > 0) {
+		penalty += 0.15;
+		reasons.push(`may invalidate: ${invalidation_hint}`);
+	}
+
+	const finalConfidence = Math.max(0, Math.min(1, baseConfidence - penalty));
+	const confidenceReason = reasons.length > 0 ? reasons.join('; ') : 'sufficient corroboration and freshness';
+
+	return { confidence: finalConfidence, confidence_reason: confidenceReason };
 }
 
 /**
@@ -407,4 +512,5 @@ module.exports = {
 	parseEnrichedAlertResponse,
 	analyzeNewsForSymbol,
 	parseNewsAnalysisResponse,
+	calibrateNewsConfidence,
 };

--- a/src/services/prompts/defaults/news-analysis.user.txt
+++ b/src/services/prompts/defaults/news-analysis.user.txt
@@ -14,7 +14,14 @@ Example JSON (respond with a similar structure using real values):
   "event_significance": 0.75,
   "sentiment_score": 0.45,
   "headline": "One-line event description",
-  "description": "Detailed explanation of the event with bulletpoints and bold text."
+  "description": "Detailed explanation of the event with bulletpoints and bold text.",
+  "source_count": 3,
+  "source_freshness": 0.9,
+  "source_quality": 0.8,
+  "event_age_hours": 2,
+  "time_horizon": "short_term",
+  "uncertainty_reason": "",
+  "invalidation_hint": ""
 }
 
 Field guidance:
@@ -24,6 +31,13 @@ Field guidance:
 - **sentiment_score** (number): -1.0 to 1.0 — negative = bearish, positive = bullish.
 - **headline** (string): one concise line describing the event (max ~250 chars).
 - **description** (string): Detailed explanation with enrich text using hypen bulletpoints (not asterisks), nextline and bold text for readability (up to ~2000 chars).
+- **source_count** (number): integer count of corroborating sources (0 if none, cap at 10).
+- **source_freshness** (number): 0.0 to 1.0 — how recent/correlated the sources are (1.0 = very fresh/current, 0.0 = old/stale).
+- **source_quality** (number): 0.0 to 1.0 — domain credibility and authority of the sources (1.0 = high-authority domains, 0.0 = unknown/unreliable).
+- **event_age_hours** (number): approximate age of the event in hours (use 0 for breaking, 168+ for very old).
+- **time_horizon** (string): one of **very_short_term** (minutes–hours), **short_term** (hours–days), **medium_term** (days–weeks), **long_term** (weeks+) — how long the event effect is expected to last.
+- **uncertainty_reason** (string): empty string if confident, or a brief explanation of why analysis is uncertain (e.g. "conflicting signals", "limited sources").
+- **invalidation_hint** (string): empty string if event seems valid, or a brief condition that would invalidate this event (e.g. "if price reverses below support", "if news is later denied").
 
 Event category hints:
 

--- a/tests/unit/event-detection.test.js
+++ b/tests/unit/event-detection.test.js
@@ -6,6 +6,7 @@
 const {
 	analyzeNewsForSymbol,
 	parseNewsAnalysisResponse,
+	calibrateNewsConfidence,
 } = require('../../src/services/grounding/gemini');
 const { EventCategory } = require('../../src/controllers/webhooks/handlers/newsMonitor/constants');
 
@@ -196,7 +197,13 @@ Some text after...`;
 					event_significance: 0.8,
 					sentiment_score: 0.9,
 					headline: 'Test',
-					sources: [],
+					source_count: 3,
+					source_freshness: 0.9,
+					source_quality: 0.9,
+					event_age_hours: 1,
+					time_horizon: 'short_term',
+					uncertainty_reason: '',
+					invalidation_hint: '',
 				}),
 			});
 		});
@@ -204,7 +211,7 @@ Some text after...`;
 		it('should calculate confidence using formula: 0.6*significance + 0.4*|sentiment|', async () => {
 			const result = await analyzeNewsForSymbol('BTCUSDT', 'Market context');
 
-			// confidence = (0.6 * 0.8) + (0.4 * |0.9|) = 0.48 + 0.36 = 0.84
+			// base = 0.6 * 0.8 + 0.4 * |0.9| = 0.84; good source data => no penalties
 			expect(result.confidence).toBeCloseTo(0.84, 5);
 		});
 
@@ -215,13 +222,19 @@ Some text after...`;
 					event_significance: 0.7,
 					sentiment_score: -0.8,
 					headline: 'Test',
-					sources: [],
+					source_count: 3,
+					source_freshness: 0.9,
+					source_quality: 0.9,
+					event_age_hours: 1,
+					time_horizon: 'short_term',
+					uncertainty_reason: '',
+					invalidation_hint: '',
 				}),
 			});
 
 			const result = await analyzeNewsForSymbol('BTCUSDT', 'Bearish news');
 
-			// confidence = (0.6 * 0.7) + (0.4 * |-0.8|) = 0.42 + 0.32 = 0.74
+			// base = 0.6 * 0.7 + 0.4 * |-0.8| = 0.74; good source data => no penalties
 			expect(result.confidence).toBeCloseTo(0.74, 5);
 		});
 
@@ -232,13 +245,19 @@ Some text after...`;
 					event_significance: 1.0,
 					sentiment_score: 1.0,
 					headline: 'Test',
-					sources: [],
+					source_count: 5,
+					source_freshness: 1.0,
+					source_quality: 1.0,
+					event_age_hours: 0,
+					time_horizon: 'short_term',
+					uncertainty_reason: '',
+					invalidation_hint: '',
 				}),
 			});
 
 			const result = await analyzeNewsForSymbol('BTCUSDT', 'Context');
 
-			// confidence = (0.6 * 1.0) + (0.4 * 1.0) = 1.0
+			// base = 0.6 * 1.0 + 0.4 * 1.0 = 1.0; perfect source data => no penalties
 			expect(result.confidence).toBe(1.0);
 			expect(result.confidence).toBeGreaterThanOrEqual(0);
 			expect(result.confidence).toBeLessThanOrEqual(1);
@@ -251,7 +270,13 @@ Some text after...`;
 					event_significance: 0.85,
 					sentiment_score: -0.6,
 					headline: 'SEC announcement',
-					sources: ['https://sec.gov'],
+					source_count: 2,
+					source_freshness: 0.8,
+					source_quality: 0.9,
+					event_age_hours: 2,
+					time_horizon: 'short_term',
+					uncertainty_reason: '',
+					invalidation_hint: '',
 				}),
 			});
 
@@ -263,6 +288,7 @@ Some text after...`;
 			expect(result).toHaveProperty('headline');
 			expect(result).toHaveProperty('sources');
 			expect(result).toHaveProperty('confidence');
+			expect(result).toHaveProperty('confidence_reason');
 		});
 
 		it('should throw error when Gemini call fails', async () => {
@@ -362,6 +388,303 @@ Some text after...`;
 			const result = await analyzeNewsForSymbol('XYZ', 'Normal market context');
 
 			expect(result.event_category).toBe('none');
+		});
+	});
+
+	describe('parseNewsAnalysisResponse - new source metadata fields', () => {
+		it('should parse source_count, source_freshness, source_quality from valid response', () => {
+			const response = JSON.stringify({
+				event_category: 'price_surge',
+				event_significance: 0.8,
+				sentiment_score: 0.7,
+				headline: 'Test',
+				description: 'Test description',
+				source_count: 5,
+				source_freshness: 0.9,
+				source_quality: 0.85,
+				event_age_hours: 3,
+				time_horizon: 'short_term',
+				uncertainty_reason: '',
+				invalidation_hint: '',
+			});
+
+			const result = parseNewsAnalysisResponse(response);
+
+			expect(result.source_count).toBe(5);
+			expect(result.source_freshness).toBe(0.9);
+			expect(result.source_quality).toBe(0.85);
+			expect(result.event_age_hours).toBe(3);
+			expect(result.time_horizon).toBe('short_term');
+			expect(result.uncertainty_reason).toBe('');
+			expect(result.invalidation_hint).toBe('');
+		});
+
+		it('should clamp source_count to [0, 10]', () => {
+			const over = parseNewsAnalysisResponse(JSON.stringify({
+				event_category: 'price_surge',
+				event_significance: 0.5,
+				sentiment_score: 0,
+				headline: 'Test',
+				source_count: 25,
+			}));
+			expect(over.source_count).toBe(10);
+
+			const under = parseNewsAnalysisResponse(JSON.stringify({
+				event_category: 'price_surge',
+				event_significance: 0.5,
+				sentiment_score: 0,
+				headline: 'Test',
+				source_count: -5,
+			}));
+			expect(under.source_count).toBe(0);
+		});
+
+		it('should clamp source_freshness and source_quality to [0, 1]', () => {
+			const over = parseNewsAnalysisResponse(JSON.stringify({
+				event_category: 'price_surge',
+				event_significance: 0.5,
+				sentiment_score: 0,
+				headline: 'Test',
+				source_freshness: 2.5,
+				source_quality: -0.5,
+			}));
+			expect(over.source_freshness).toBe(1);
+			expect(over.source_quality).toBe(0);
+		});
+
+		it('should apply defaults for missing new fields (backward compat)', () => {
+			const legacyResponse = JSON.stringify({
+				event_category: 'price_surge',
+				event_significance: 0.5,
+				sentiment_score: 0.3,
+				headline: 'Test',
+			});
+
+			const result = parseNewsAnalysisResponse(legacyResponse);
+
+			expect(result.source_count).toBe(0);
+			expect(result.source_freshness).toBe(0.5);
+			expect(result.source_quality).toBe(0.5);
+			expect(result.event_age_hours).toBeNull();
+			expect(result.time_horizon).toBe('short_term');
+			expect(result.uncertainty_reason).toBe('');
+			expect(result.invalidation_hint).toBe('');
+		});
+
+		it('should round source_count to an integer', () => {
+			const result = parseNewsAnalysisResponse(JSON.stringify({
+				event_category: 'price_surge',
+				event_significance: 0.5,
+				sentiment_score: 0,
+				headline: 'Test',
+				source_count: 3.7,
+			}));
+			expect(result.source_count).toBe(4);
+		});
+
+		it('should set time_horizon default for invalid values', () => {
+			const result = parseNewsAnalysisResponse(JSON.stringify({
+				event_category: 'price_surge',
+				event_significance: 0.5,
+				sentiment_score: 0,
+				headline: 'Test',
+				time_horizon: 'invalid_value',
+			}));
+			expect(result.time_horizon).toBe('short_term');
+		});
+
+		it('should trim uncertainty_reason and invalidation_hint', () => {
+			const result = parseNewsAnalysisResponse(JSON.stringify({
+				event_category: 'price_surge',
+				event_significance: 0.5,
+				sentiment_score: 0,
+				headline: 'Test',
+				uncertainty_reason: '  conflicting signals  ',
+				invalidation_hint: '  price reversal possible  ',
+			}));
+			expect(result.uncertainty_reason).toBe('conflicting signals');
+			expect(result.invalidation_hint).toBe('price reversal possible');
+		});
+
+		it('should include new fields in fallback response on parse error', () => {
+			const result = parseNewsAnalysisResponse('not valid json');
+			expect(result.event_category).toBe(EventCategory.NONE);
+			expect(result.source_count).toBe(0);
+			expect(result.source_freshness).toBe(0);
+			expect(result.source_quality).toBe(0);
+			expect(result.event_age_hours).toBeNull();
+			expect(result.time_horizon).toBe('short_term');
+			expect(result.uncertainty_reason).toBe('parse error');
+			expect(result.invalidation_hint).toBe('');
+		});
+	});
+
+	describe('calibrateNewsConfidence', () => {
+		it('should return high confidence for high-quality multi-source news', () => {
+			const result = calibrateNewsConfidence({
+				event_significance: 0.9,
+				sentiment_score: 0.8,
+				source_count: 3,
+				source_freshness: 0.95,
+				source_quality: 0.9,
+				uncertainty_reason: '',
+				invalidation_hint: '',
+			});
+
+			expect(result.confidence).toBeGreaterThan(0.7);
+			expect(result.confidence_reason).toContain('sufficient corroboration');
+			expect(result.confidence).toBeLessThanOrEqual(1);
+		});
+
+		it('should penalize single-source news', () => {
+			const multiSource = calibrateNewsConfidence({
+				event_significance: 0.9,
+				sentiment_score: 0.8,
+				source_count: 3,
+				source_freshness: 0.9,
+				source_quality: 0.9,
+				uncertainty_reason: '',
+				invalidation_hint: '',
+			});
+
+			const singleSource = calibrateNewsConfidence({
+				event_significance: 0.9,
+				sentiment_score: 0.8,
+				source_count: 1,
+				source_freshness: 0.9,
+				source_quality: 0.9,
+				uncertainty_reason: '',
+				invalidation_hint: '',
+			});
+
+			expect(singleSource.confidence).toBeLessThan(multiSource.confidence);
+			expect(singleSource.confidence_reason).toContain('single source');
+		});
+
+		it('should penalize stale sources (low freshness)', () => {
+			const fresh = calibrateNewsConfidence({
+				event_significance: 0.8,
+				sentiment_score: 0.7,
+				source_count: 3,
+				source_freshness: 0.95,
+				source_quality: 0.8,
+				uncertainty_reason: '',
+				invalidation_hint: '',
+			});
+
+			const stale = calibrateNewsConfidence({
+				event_significance: 0.8,
+				sentiment_score: 0.7,
+				source_count: 3,
+				source_freshness: 0.2,
+				source_quality: 0.8,
+				uncertainty_reason: '',
+				invalidation_hint: '',
+			});
+
+			expect(stale.confidence).toBeLessThan(fresh.confidence);
+			expect(stale.confidence_reason).toContain('stale');
+		});
+
+		it('should penalize low-quality/unreliable sources', () => {
+			const highQuality = calibrateNewsConfidence({
+				event_significance: 0.8,
+				sentiment_score: 0.7,
+				source_count: 3,
+				source_freshness: 0.9,
+				source_quality: 0.9,
+				uncertainty_reason: '',
+				invalidation_hint: '',
+			});
+
+			const lowQuality = calibrateNewsConfidence({
+				event_significance: 0.8,
+				sentiment_score: 0.7,
+				source_count: 3,
+				source_freshness: 0.9,
+				source_quality: 0.2,
+				uncertainty_reason: '',
+				invalidation_hint: '',
+			});
+
+			expect(lowQuality.confidence).toBeLessThan(highQuality.confidence);
+			expect(lowQuality.confidence_reason).toContain('low source authority');
+		});
+
+		it('should penalize uncertainty and invalidation hints', () => {
+			const clean = calibrateNewsConfidence({
+				event_significance: 0.8,
+				sentiment_score: 0.7,
+				source_count: 3,
+				source_freshness: 0.9,
+				source_quality: 0.8,
+				uncertainty_reason: '',
+				invalidation_hint: '',
+			});
+
+			const uncertain = calibrateNewsConfidence({
+				event_significance: 0.8,
+				sentiment_score: 0.7,
+				source_count: 3,
+				source_freshness: 0.9,
+				source_quality: 0.8,
+				uncertainty_reason: 'conflicting signals',
+				invalidation_hint: '',
+			});
+
+			const invalidatable = calibrateNewsConfidence({
+				event_significance: 0.8,
+				sentiment_score: 0.7,
+				source_count: 3,
+				source_freshness: 0.9,
+				source_quality: 0.8,
+				uncertainty_reason: '',
+				invalidation_hint: 'if price reverses below support',
+			});
+
+			expect(uncertain.confidence).toBeLessThan(clean.confidence);
+			expect(uncertain.confidence_reason).toContain('conflicting signals');
+			expect(invalidatable.confidence).toBeLessThan(clean.confidence);
+			expect(invalidatable.confidence_reason).toContain('may invalidate');
+		});
+
+		it('should return 0 confidence when penalties exceed base', () => {
+			const result = calibrateNewsConfidence({
+				event_significance: 0,
+				sentiment_score: 0,
+				source_count: 0,
+				source_freshness: 0,
+				source_quality: 0,
+				uncertainty_reason: 'no reliable data',
+				invalidation_hint: 'everything is uncertain',
+			});
+
+			expect(result.confidence).toBe(0);
+			expect(result.confidence_reason).toBeTruthy();
+		});
+
+		it('should clamp confidence to [0, 1]', () => {
+			const over = calibrateNewsConfidence({
+				event_significance: 2,
+				sentiment_score: 2,
+				source_count: 10,
+				source_freshness: 1,
+				source_quality: 1,
+				uncertainty_reason: '',
+				invalidation_hint: '',
+			});
+			expect(over.confidence).toBeLessThanOrEqual(1);
+
+			const under = calibrateNewsConfidence({
+				event_significance: -0.5,
+				sentiment_score: -0.5,
+				source_count: 0,
+				source_freshness: 0,
+				source_quality: 0,
+				uncertainty_reason: 'all bad',
+				invalidation_hint: 'everything is uncertain',
+			});
+			expect(under.confidence).toBeGreaterThanOrEqual(0);
 		});
 	});
 });


### PR DESCRIPTION
feat(news): calibrate confidence with source quality and freshness (CB-40)

## Summary

Extend the news-analysis prompt and parser to return decision-support metadata (source_count, source_freshness, source_quality, event_age_hours, time_horizon, uncertainty_reason, invalidation_hint) and apply a deterministic confidence-calibration function that penalizes stale, single-source, or uncorroborated events.

## Key Changes

- **Prompt schema**: Added 7 new fields to the news-analysis prompt JSON schema so Gemini returns source metadata alongside event analysis.
- **Parser**: Extended `parseNewsAnalysisResponse()` to clamp/validate new fields with fail-open defaults on parse errors.
- **Confidence calibration**: New `calibrateNewsConfidence()` replaces the simple 0.6/0.4 formula with up to 4 penalty axes: source count (up to 30% for 0 sources), source freshness (up to 15% for stale), source authority (up to 20% for low quality), and uncertainty/invalidation hints (10-15%).
- **Alert enrichment**: `confidence_reason` is now included in the alert object and displayed in formatted messages, explaining why confidence passed or fell short.
- **Backward compatibility**: Legacy Gemini responses without the new fields use safe defaults (source_count=0, freshness=0.5, quality=0.5) so the calibration still applies a reasonable penalty.

## Technical Implementation

### `calibrateNewsConfidence(analysisResult)`

```js
base = 0.6 * event_significance + 0.4 * abs(sentiment_score)
penalty = fn(source_count) + fn(source_freshness) + fn(source_quality) + fn(uncertainty) + fn(invalidation)
confidence = clamp(base - penalty, 0, 1)
confidence_reason = "sufficient corroboration" | "no corroborating sources; stale; ..."
```

### Files Changed

- `src/services/prompts/defaults/news-analysis.user.txt` — Extended JSON schema with source metadata.
- `src/services/grounding/gemini.js` — Extended parser + new confidence calibration function.
- `src/controllers/webhooks/handlers/newsMonitor/analyzer.js` — `buildAlert()` and `formatAlertMessage()` include `confidence_reason`.

## Testing

- 37 event detection tests pass (including 8 new parse tests and 7 calibration tests).
- 505 unit tests pass across the repo.
- 260 integration tests pass.
- Regression: existing tests updated with source metadata to maintain expected confidence values.

## References

- **GitHub Issue**: https://github.com/francovp/cabros-bot/issues/127
- **Linear**: [CB-40](https://linear.app/knil/issue/CB-40/calibrate-news-confidence-with-source-quality-and-freshness)