### PR TITLE
feat(report): add risk reward targets

### DIFF
--- a/src/services/tradingview/expandedAnalysisAlertReport.js
+++ b/src/services/tradingview/expandedAnalysisAlertReport.js
@@ -209,7 +209,11 @@ function buildReportRow({ input = {}, analysis = {}, multiTimeframe }) {
 	const trend = getTrend(price, sma20);
 	const macdDirection = getMacdDirection(macd, macdSignal);
 	const volume = getVolumeLabel(techData);
-	const stopLoss = getStopLoss(price, atr, bollinger, currentBollinger);
+	const stopLossMeta = getStopLossMeta(price, atr, bollinger, currentBollinger);
+	const stopLoss = stopLossMeta.value;
+	const takeProfit = getTakeProfitTarget(price, atr, bollinger, currentBollinger, techData);
+	const invalidationDistance = getInvalidationDistance(price, stopLoss, stopLossMeta.source);
+	const riskRewardRatio = getRiskRewardRatio(price, stopLoss, takeProfit);
 
 	const sentiment = analysis.sentiment || null;
 	const confluence = analysis.confluence || null;
@@ -225,6 +229,9 @@ function buildReportRow({ input = {}, analysis = {}, multiTimeframe }) {
 		volume,
 		atr,
 		stopLoss,
+		takeProfit,
+		invalidationDistance,
+		riskRewardRatio,
 		suggestion: getSuggestion({ rsi, trend, macdDirection }),
 		multiTimeframe,
 		sentiment,
@@ -244,8 +251,11 @@ function formatGroupRows(rows) {
 			`- *Tendencia (SMA20):* ${row.trend} | *MACD:* ${row.macdDirection}`,
 			formatVolumeAtrLine(row),
 			`- *Stop Loss sugerido:* ${formatCurrency(row.stopLoss)}`,
+			formatTargetLine(row),
+			formatRiskRewardLine(row),
+			formatInvalidationLine(row),
 			`- *Sugerencia:* ${row.suggestion}`,
-		];
+		].filter(Boolean);
 
 		if (row.sentiment) {
 			const sentText = formatRedditSentiment(row.sentiment);
@@ -373,7 +383,7 @@ function formatMultiTimeframeSection(mtf) {
 	});
 
 	return [
-		`- *Alineación Multi-TF:*`,
+		'- *Alineación Multi-TF:*',
 		...tfLines,
 		`  • *Confluencia:* ${alignment.status || 'N/A'} (Confianza: ${alignment.confidence || 'N/A'})`,
 		`  • *Recomendación:* ${rec.action || 'N/A'}`,
@@ -490,21 +500,106 @@ function getVolumeLabel(analysis) {
 	return 'Normal';
 }
 
-function getStopLoss(price, atr, bollinger, currentBollinger = {}) {
+function getStopLossMeta(price, atr, bollinger, currentBollinger = {}) {
 	if (price === null) {
-		return null;
+		return { value: null, source: 'missing' };
 	}
 
 	if (atr !== null) {
-		return price - (atr * 1.5);
+		return { value: price - (atr * 1.5), source: 'atr' };
 	}
 
 	const bbLower = numberOrNull(bollinger.bb_lower ?? currentBollinger.lower);
 	if (bbLower !== null) {
-		return bbLower;
+		return { value: bbLower, source: 'bollinger' };
 	}
 
-	return price * 0.95;
+	return { value: price * 0.95, source: 'fallback' };
+}
+
+function getTakeProfitTarget(price, atr, bollinger, currentBollinger = {}, techData = {}) {
+	if (price === null) {
+		return null;
+	}
+
+	const nearestResistance = numberOrNull(
+		techData.support_resistance?.nearest_resistance
+		?? techData.support_resistance?.resistance_1
+		?? techData.resistance?.nearest,
+	);
+	if (nearestResistance !== null && nearestResistance > price) {
+		return nearestResistance;
+	}
+
+	const bbUpper = numberOrNull(bollinger.bb_upper ?? currentBollinger.upper);
+	if (bbUpper !== null && bbUpper > price) {
+		return bbUpper;
+	}
+
+	if (atr !== null) {
+		return price + (atr * 3);
+	}
+
+	return null;
+}
+
+function getInvalidationDistance(price, stopLoss, stopLossSource) {
+	if (price === null || stopLoss === null || stopLossSource === 'fallback') {
+		return null;
+	}
+
+	return Math.max(price - stopLoss, 0);
+}
+
+function getRiskRewardRatio(price, stopLoss, takeProfit) {
+	if (price === null || stopLoss === null || takeProfit === null) {
+		return null;
+	}
+
+	const risk = price - stopLoss;
+	const reward = takeProfit - price;
+
+	if (risk <= 0 || reward <= 0) {
+		return null;
+	}
+
+	return reward / risk;
+}
+
+function formatTargetLine(row) {
+	if (row.takeProfit === null) {
+		return null;
+	}
+
+	return `- *Target sugerido:* ${formatCurrency(row.takeProfit)}`;
+}
+
+function formatRiskRewardLine(row) {
+	if (row.riskRewardRatio === null) {
+		return null;
+	}
+
+	return `- *Risk/Reward:* ${formatNumber(row.riskRewardRatio, 2)}x · Setup ${classifyRiskReward(row.riskRewardRatio)}`;
+}
+
+function formatInvalidationLine(row) {
+	if (row.invalidationDistance === null) {
+		return null;
+	}
+
+	return `- *Invalidación:* ${formatCurrency(row.invalidationDistance)} por debajo del precio actual`;
+}
+
+function classifyRiskReward(ratio) {
+	if (ratio >= 2) {
+		return 'favorable';
+	}
+
+	if (ratio >= 1) {
+		return 'neutral';
+	}
+
+	return 'poor';
 }
 
 function getSuggestion({ rsi, trend, macdDirection }) {

--- a/src/services/tradingview/expandedAnalysisAlertReport.js
+++ b/src/services/tradingview/expandedAnalysisAlertReport.js
@@ -211,7 +211,10 @@ function buildReportRow({ input = {}, analysis = {}, multiTimeframe }) {
 	const volume = getVolumeLabel(techData);
 	const stopLossMeta = getStopLossMeta(price, atr, bollinger, currentBollinger);
 	const stopLoss = stopLossMeta.value;
-	const takeProfit = getTakeProfitTarget(price, atr, bollinger, currentBollinger, techData);
+	const isOverbought = rsi !== null && rsi > 70;
+	const takeProfit = isOverbought
+		? null
+		: getTakeProfitTarget(price, atr, bollinger, currentBollinger, techData);
 	const invalidationDistance = getInvalidationDistance(price, stopLoss, stopLossMeta.source);
 	const riskRewardRatio = getRiskRewardRatio(price, stopLoss, takeProfit);
 
@@ -544,7 +547,7 @@ function getTakeProfitTarget(price, atr, bollinger, currentBollinger = {}, techD
 }
 
 function getInvalidationDistance(price, stopLoss, stopLossSource) {
-	if (price === null || stopLoss === null || stopLossSource === 'fallback') {
+	if (price === null || stopLoss === null || stopLossSource === 'fallback' || stopLoss >= price) {
 		return null;
 	}
 

--- a/tests/unit/expanded-analysis-alert-report.test.js
+++ b/tests/unit/expanded-analysis-alert-report.test.js
@@ -169,6 +169,112 @@ describe('Expanded Analysis Alert report', () => {
 		expect(report).toContain('- *Stop Loss sugerido:* $194.22');
 	});
 
+	it('renders target, risk reward, and invalidation for deterministic ATR-based setups', () => {
+		const report = buildExpandedAnalysisAlertReport([
+			{
+				input: { raw: 'NASDAQ:AMD', exchange: 'NASDAQ', symbol: 'AMD' },
+				analysis: {
+					price_data: {
+						current_price: 100,
+						change_percent: 2.5,
+					},
+					technical_indicators: {
+						rsi: 54.2,
+						sma20: 98,
+						macd: 1.2,
+						macd_signal: 0.8,
+						atr: 4,
+					},
+				},
+			},
+		], { now: new Date('2026-05-22T12:00:00Z') });
+
+		expect(report).toContain('- *Target sugerido:* $112.00');
+		expect(report).toContain('- *Risk/Reward:* 2.00x · Setup favorable');
+		expect(report).toContain('- *Invalidación:* $6.00 por debajo del precio actual');
+	});
+
+	it('renders target, risk reward, and invalidation for deterministic Bollinger-based setups', () => {
+		const report = buildExpandedAnalysisAlertReport([
+			{
+				input: { raw: 'NASDAQ:NVDA', exchange: 'NASDAQ', symbol: 'NVDA' },
+				analysis: {
+					price_data: {
+						current_price: 100,
+						change_percent: 2.5,
+					},
+					technical_indicators: {
+						rsi: 54.2,
+						sma20: 98,
+						macd: 1.2,
+						macd_signal: 0.8,
+						atr: 4,
+					},
+					bollinger_bands: {
+						upper: 112,
+						lower: 94,
+					},
+				},
+			},
+		], { now: new Date('2026-05-22T12:00:00Z') });
+
+		expect(report).toContain('- *Target sugerido:* $112.00');
+		expect(report).toContain('- *Risk/Reward:* 2.00x · Setup favorable');
+		expect(report).toContain('- *Invalidación:* $6.00 por debajo del precio actual');
+	});
+
+	it('prefers nearest resistance over Bollinger and ATR targets', () => {
+		const report = buildExpandedAnalysisAlertReport([
+			{
+				input: { raw: 'NASDAQ:AAPL', exchange: 'NASDAQ', symbol: 'AAPL' },
+				analysis: {
+					price_data: {
+						current_price: 200,
+						change_percent: 1.2,
+					},
+					technical_indicators: {
+						rsi: 58,
+						sma20: 198,
+						macd: 1.5,
+						macd_signal: 1.2,
+						atr: 5,
+					},
+					bollinger_bands: {
+						upper: 210,
+						lower: 190,
+					},
+					support_resistance: {
+						nearest_resistance: 215,
+					},
+				},
+			},
+		], { now: new Date('2026-05-22T12:00:00Z') });
+
+		expect(report).toContain('- *Target sugerido:* $215.00');
+		expect(report).toContain('- *Risk/Reward:* 2.00x · Setup favorable');
+	});
+
+	it('omits target and risk reward when the report lacks enough data', () => {
+		const report = buildExpandedAnalysisAlertReport([
+			{
+				input: { raw: 'NASDAQ:TSLA', exchange: 'NASDAQ', symbol: 'TSLA' },
+				analysis: {
+					price_data: {
+						current_price: 250,
+						change_percent: -0.4,
+					},
+					technical_indicators: {
+						rsi: 49.5,
+					},
+				},
+			},
+		], { now: new Date('2026-05-22T12:00:00Z') });
+
+		expect(report).not.toContain('Target sugerido');
+		expect(report).not.toContain('Risk/Reward');
+		expect(report).not.toContain('Invalidación');
+	});
+
 	describe('includeMultiTimeframe updates', () => {
 		it('parses includeMultiTimeframe and include_multi_timeframe correctly', () => {
 			const parsed1 = parseExpandedAnalysisAlertRequest({

--- a/tests/unit/expanded-analysis-alert-report.test.js
+++ b/tests/unit/expanded-analysis-alert-report.test.js
@@ -275,6 +275,59 @@ describe('Expanded Analysis Alert report', () => {
 		expect(report).not.toContain('Invalidación');
 	});
 
+	it('omits long target output for overbought sell setups', () => {
+		const report = buildExpandedAnalysisAlertReport([
+			{
+				input: { raw: 'NASDAQ:AAPL', exchange: 'NASDAQ', symbol: 'AAPL' },
+				analysis: {
+					price_data: {
+						current_price: 304.99,
+						change_percent: 0.9,
+					},
+					technical_indicators: {
+						rsi: 76.2,
+						sma20: 296.5,
+						macd: 2.3,
+						macd_signal: 1.1,
+						atr: 5.91,
+					},
+				},
+			},
+		], { now: new Date('2026-05-22T12:00:00Z') });
+
+		expect(report).toContain('- *Sugerencia:* VENDER / TOMAR GANANCIAS');
+		expect(report).not.toContain('Target sugerido');
+		expect(report).not.toContain('Risk/Reward');
+	});
+
+	it('omits invalidation when the stop loss is above the current price', () => {
+		const report = buildExpandedAnalysisAlertReport([
+			{
+				input: { raw: 'NASDAQ:NVDA', exchange: 'NASDAQ', symbol: 'NVDA' },
+				analysis: {
+					price_data: {
+						current_price: 100,
+						change_percent: -1.1,
+					},
+					technical_indicators: {
+						rsi: 45,
+						sma20: 102,
+						macd: -0.4,
+						macd_signal: -0.6,
+					},
+					bollinger_bands: {
+						lower: 105,
+						upper: 120,
+					},
+				},
+			},
+		], { now: new Date('2026-05-22T12:00:00Z') });
+
+		expect(report).toContain('- *Stop Loss sugerido:* $105.00');
+		expect(report).not.toContain('Invalidación');
+		expect(report).not.toContain('Risk/Reward');
+	});
+
 	describe('includeMultiTimeframe updates', () => {
 		it('parses includeMultiTimeframe and include_multi_timeframe correctly', () => {
 			const parsed1 = parseExpandedAnalysisAlertRequest({


### PR DESCRIPTION
## Summary

Add deterministic take-profit, invalidation distance, and risk/reward guidance to expanded analysis reports for GH-128 without inventing values when source data is insufficient.

## Key Changes

### :chart_with_upwards_trend: Deterministic target derivation

- Added take-profit derivation priority in `expandedAnalysisAlertReport` using nearest resistance first, then Bollinger upper band, then ATR multiples.
- Kept the existing stop-loss calculation intact while exposing additional derived metadata for report rows.
- Added setup classification output (`favorable`, `neutral`, `poor`) from the computed risk/reward ratio.

### :memo: Expanded Spanish report output

- Added concise report lines for `Target sugerido`, `Risk/Reward`, and `Invalidación`.
- Omitted the new lines when the report lacks enough source data to compute them safely.
- Avoided showing invalidation when the stop loss only comes from the generic fallback path.
- Suppressed contradictory long-target output for overbought sell setups and hidden invalidation when the stop sits above the current price.

### :test_tube: Verification coverage

- Added unit coverage for ATR-based, Bollinger-based, support/resistance-based, and missing-data scenarios.
- Re-ran the expanded analysis endpoint integration suite to confirm the route still builds and delivers the report correctly.

## Technical Implementation

### Architecture changes

#### `src/services/tradingview/expandedAnalysisAlertReport.js`

- Added row-level derived fields for `takeProfit`, `invalidationDistance`, and `riskRewardRatio`.
- Introduced helper functions to compute target selection, invalidation distance, risk/reward ratio, and setup classification.
- Preserved existing request parsing, delivery behavior, and stop-loss formatting.

## Testing infraestructure

### Test Coverage

- Updated `tests/unit/expanded-analysis-alert-report.test.js` with deterministic output assertions for:
- ATR-only targets
- Bollinger-based targets
- Resistance-priority targets
- Missing-data omission behavior
- Overbought sell-row suppression behavior
- Stop-above-price invalidation suppression behavior

### Test Files

- `tests/unit/expanded-analysis-alert-report.test.js`: report formatting and risk/reward coverage
- `tests/integration/expanded-analysis-alert-endpoint.test.js`: endpoint regression coverage for expanded analysis delivery

## Documentation Updates

- **Implementation Plan** Saved a local implementation plan at `docs/superpowers/plans/2026-06-28-gh-128-risk-reward-targets.md`

## Examples

```text
- *Target sugerido:* $112.00
- *Risk/Reward:* 2.00x · Setup favorable
- *Invalidación:* $6.00 por debajo del precio actual
```

## Testing

### Pre-merge Verification

- [ ] Re-run `pnpm test -- --runInBand tests/unit/expanded-analysis-alert-report.test.js`
- [ ] Re-run `pnpm test -- --runInBand tests/integration/expanded-analysis-alert-endpoint.test.js`
- [ ] Re-run `pnpm eslint src/services/tradingview/expandedAnalysisAlertReport.js tests/unit/expanded-analysis-alert-report.test.js`

## References

- Fixes #128
- Linear: `CB-41`

---

**Review Checklist:**

- [ ] Code quality meets project standards
- [ ] All tests pass and coverage is maintained
- [ ] Documentation is complete and accurate
- [ ] Breaking change assessment completed
