### PR TITLE
fix: implement private-network callback URL blocking (CB-55)

### DIFF
--- a/CabrosBot.postman_collection.json
+++ b/CabrosBot.postman_collection.json
@@ -1062,7 +1062,29 @@
 							},
 							"status": "Bad Request",
 							"code": 400,
-							"body": "{\n  \"error\": \"callbackUrl must be a valid HTTPS URL (except localhost/127.0.0.1 in non-prod environments)\",\n  \"code\": \"INVALID_REQUEST\"\n}"
+							"body": "{\n  \"error\": \"callbackUrl must be a valid HTTPS URL (HTTP only allowed for local development)\",\n  \"code\": \"INVALID_REQUEST\"\n}"
+						},
+						{
+							"name": "Create Job with Private Callback URL (SSRF Blocked)",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{ "key": "Content-Type", "value": "application/json", "type": "text" },
+									{ "key": "x-api-key", "value": "{{apiKey}}", "type": "text" }
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"type\": \"expanded-analysis\",\n  \"symbols\": [\"BINANCE:BTCUSDT\"],\n  \"callbackUrl\": \"https://169.254.169.254/api/callback\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/jobs/tradingview-analysis",
+									"host": ["{{baseUrl}}"],
+									"path": ["api", "jobs", "tradingview-analysis"]
+								}
+							},
+							"status": "Bad Request",
+							"code": 400,
+							"body": "{\n  \"error\": \"callbackUrl must be a valid HTTPS URL (HTTP only allowed for local development)\",\n  \"code\": \"INVALID_REQUEST\"\n}"
 						}
 					]
 				},

--- a/agents.md
+++ b/agents.md
@@ -1030,3 +1030,20 @@ This feature introduces integration of the official `openai` SDK to interact wit
 **Testing**:
 - Unit coverage in `tests/unit/cloudflare-client.test.js`.
 - Integration coverage in `tests/integration/status-endpoint.test.js`.
+
+## Private Network SSRF Protection for Job Callbacks (CB-55 / Issue #152)
+
+This feature introduces validation of callback URLs to prevent Server-Side Request Forgery (SSRF) by blocking private-network, loopback, link-local, RFC1918, multicast, and metadata-service ranges during both callback URL acceptance (creation) and delivery (sending).
+
+**Core Components**:
+- `src/services/jobs/JobService.js` — Contains `isPrivateIp` IP range checks and `isValidCallbackUrl` async validation. Validates URL protocol, keeps HTTP-local allowance for tests/dev, and performs async DNS resolution of hostnames before checking resolved IP address ranges.
+- `tests/unit/job-service.test.js` — Standard unit tests covering loopback, link-local, RFC1918, multicast, and metadata-service (e.g. `169.254.169.254`) ranges.
+- `tests/integration/jobs-endpoint.test.js` — Endpoint verification tests checking HTTP 400 Bad Request responses for private callback URLs.
+
+**Configuration**:
+- `ALLOW_PRIVATE_CALLBACKS` — Set to `'true'` to bypass private-network/SSRF blocking on callback URLs (e.g. for local developer testing of private targets). Defaults to `'false'`.
+- `ALLOW_HTTP_CALLBACKS` — Existing flag to permit plain HTTP callbacks (restricted to localhost unless `NODE_ENV=test` or set to `'true'`).
+
+**Testing**:
+- Unit coverage: `pnpm test -- tests/unit/job-service.test.js`
+- Integration coverage: `pnpm test -- tests/integration/jobs-endpoint.test.js`

--- a/agents.md
+++ b/agents.md
@@ -1036,8 +1036,8 @@ This feature introduces integration of the official `openai` SDK to interact wit
 This feature introduces validation of callback URLs to prevent Server-Side Request Forgery (SSRF) by blocking private-network, loopback, link-local, RFC1918, multicast, and metadata-service ranges during both callback URL acceptance (creation) and delivery (sending).
 
 **Core Components**:
-- `src/services/jobs/JobService.js` — Contains `isPrivateIp` IP range checks and `isValidCallbackUrl` async validation. Validates URL protocol, keeps HTTP-local allowance for tests/dev, and performs async DNS resolution of hostnames before checking resolved IP address ranges.
-- `tests/unit/job-service.test.js` — Standard unit tests covering loopback, link-local, RFC1918, multicast, and metadata-service (e.g. `169.254.169.254`) ranges.
+- `src/services/jobs/JobService.js` — Contains `isPrivateIp` IP range checks and `isValidCallbackUrl` async validation. Validates URL protocol, normalizes bracketed IPv6 literals, rejects a hostname when any DNS answer is private, revalidates before every delivery attempt, and disables automatic redirects.
+- `tests/unit/job-service.test.js` — Unit tests covering loopback, link-local, RFC1918, multicast, metadata-service (e.g. `169.254.169.254`), mixed public/private DNS answers, public IPv6 literals, redirect policy, and DNS changes between retries.
 - `tests/integration/jobs-endpoint.test.js` — Endpoint verification tests checking HTTP 400 Bad Request responses for private callback URLs.
 
 **Configuration**:

--- a/src/services/jobs/JobService.js
+++ b/src/services/jobs/JobService.js
@@ -65,7 +65,7 @@ function isPrivateIp(ip) {
 		if (parts[0] === 10) return true; // RFC1918
 		if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true; // RFC1918
 		if (parts[0] === 192 && parts[1] === 168) return true; // RFC1918
-		if (parts[0] === 192 && parts[1] === 0) return true; // IETF special-purpose
+		if (parts[0] === 192 && parts[1] === 0 && parts[2] === 0) return true; // IETF special-purpose
 		if (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) return true; // RFC6598 shared address space
 		if (parts[0] === 169 && parts[1] === 254) return true; // Link-local (includes 169.254.169.254)
 		if (parts[0] === 198 && (parts[1] === 18 || parts[1] === 19)) return true; // Benchmarking

--- a/src/services/jobs/JobService.js
+++ b/src/services/jobs/JobService.js
@@ -64,6 +64,7 @@ function isPrivateIp(ip) {
 		if (parts[0] === 10) return true; // RFC1918
 		if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true; // RFC1918
 		if (parts[0] === 192 && parts[1] === 168) return true; // RFC1918
+		if (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) return true; // RFC6598 shared address space
 		if (parts[0] === 169 && parts[1] === 254) return true; // Link-local (includes 169.254.169.254)
 		if (parts[0] >= 224 && parts[0] <= 239) return true; // Multicast
 		if (parts[0] === 0 && parts[1] === 0 && parts[2] === 0 && parts[3] === 0) return true;
@@ -109,11 +110,11 @@ function normalizeHostname(hostname) {
 	return hostname;
 }
 
-async function isValidCallbackUrl(urlStr) {
+async function validateCallbackUrl(urlStr) {
 	try {
 		const url = new URL(urlStr);
 		if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-			return false;
+			return { valid: false, reason: 'format' };
 		}
 
 		const hostname = normalizeHostname(url.hostname);
@@ -125,7 +126,7 @@ async function isValidCallbackUrl(urlStr) {
 				process.env.NODE_ENV === 'test' ||
 				process.env.ALLOW_HTTP_CALLBACKS === 'true';
 			if (!httpAllowed) {
-				return false;
+				return { valid: false, reason: 'format' };
 			}
 		}
 
@@ -133,7 +134,7 @@ async function isValidCallbackUrl(urlStr) {
 			process.env.NODE_ENV === 'test';
 
 		if (allowPrivate) {
-			return true;
+			return { valid: true };
 		}
 
 		let addresses;
@@ -143,18 +144,23 @@ async function isValidCallbackUrl(urlStr) {
 			try {
 				addresses = await dns.promises.lookup(hostname, { all: true, verbatim: true });
 			} catch (dnsErr) {
-				return false; // DNS resolution failed
+				return { valid: false, reason: 'dns' };
 			}
 		}
 
 		if (!addresses.length || addresses.some(({ address }) => isPrivateIp(address))) {
-			return false;
+			return { valid: false, reason: 'private' };
 		}
 
-		return true;
+		return { valid: true };
 	} catch (err) {
-		return false;
+		return { valid: false, reason: 'format' };
 	}
+}
+
+async function isValidCallbackUrl(urlStr) {
+	const result = await validateCallbackUrl(urlStr);
+	return result.valid;
 }
 
 class JobService {
@@ -1100,15 +1106,26 @@ class JobService {
 		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 			const timestamp = new Date().toISOString();
 
-			if (!await isValidCallbackUrl(callbackUrl)) {
-				console.warn(`[JobService] Aborting callback to unsafe URL: ${callbackUrl}`);
+			const callbackUrlValidation = await validateCallbackUrl(callbackUrl);
+			if (!callbackUrlValidation.valid) {
+				const isRetryableValidationFailure = callbackUrlValidation.reason === 'dns';
+				console.warn(`[JobService] ${isRetryableValidationFailure ? 'Retrying callback after validation failure' : 'Aborting callback to unsafe URL'}: ${callbackUrl}`);
 				attempts.push({
 					attempt,
 					event: callbackEvent,
 					timestamp,
-					error: 'Callback URL is blocked (private network)',
+					error: isRetryableValidationFailure
+						? 'Callback URL validation failed'
+						: 'Callback URL is blocked (private network)',
 				});
-				break;
+				if (!isRetryableValidationFailure) {
+					break;
+				}
+				if (attempt < maxAttempts) {
+					await new Promise((resolve) => setTimeout(resolve, delayMs));
+					delayMs *= 2;
+				}
+				continue;
 			}
 
 			const controller = new AbortController();

--- a/src/services/jobs/JobService.js
+++ b/src/services/jobs/JobService.js
@@ -60,14 +60,19 @@ function isPrivateIp(ip) {
 		const parts = cleanIp.split('.').map(Number);
 		if (parts.length !== 4 || parts.some(isNaN)) return true;
 
+		if (parts[0] === 0) return true; // Current network / software-only
 		if (parts[0] === 127) return true; // Loopback
 		if (parts[0] === 10) return true; // RFC1918
 		if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true; // RFC1918
 		if (parts[0] === 192 && parts[1] === 168) return true; // RFC1918
+		if (parts[0] === 192 && parts[1] === 0) return true; // IETF special-purpose
 		if (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) return true; // RFC6598 shared address space
 		if (parts[0] === 169 && parts[1] === 254) return true; // Link-local (includes 169.254.169.254)
+		if (parts[0] === 198 && (parts[1] === 18 || parts[1] === 19)) return true; // Benchmarking
+		if (parts[0] === 198 && parts[1] === 51 && parts[2] === 100) return true; // Documentation
+		if (parts[0] === 203 && parts[1] === 0 && parts[2] === 113) return true; // Documentation
 		if (parts[0] >= 224 && parts[0] <= 239) return true; // Multicast
-		if (parts[0] === 0 && parts[1] === 0 && parts[2] === 0 && parts[3] === 0) return true;
+		if (parts[0] >= 240) return true; // Reserved / limited broadcast
 		if (parts[0] === 255 && parts[1] === 255 && parts[2] === 255 && parts[3] === 255) return true;
 
 		return false;
@@ -108,6 +113,20 @@ function normalizeHostname(hostname) {
 		return hostname.slice(1, -1);
 	}
 	return hostname;
+}
+
+function sanitizeCallbackUrlForLog(urlStr) {
+	try {
+		const url = new URL(urlStr);
+		url.username = '';
+		url.password = '';
+		url.pathname = '/...';
+		url.search = '';
+		url.hash = '';
+		return url.toString();
+	} catch (err) {
+		return '[invalid callback URL]';
+	}
 }
 
 async function validateCallbackUrl(urlStr) {
@@ -1109,7 +1128,10 @@ class JobService {
 			const callbackUrlValidation = await validateCallbackUrl(callbackUrl);
 			if (!callbackUrlValidation.valid) {
 				const isRetryableValidationFailure = callbackUrlValidation.reason === 'dns';
-				console.warn(`[JobService] ${isRetryableValidationFailure ? 'Retrying callback after validation failure' : 'Aborting callback to unsafe URL'}: ${callbackUrl}`);
+				console.warn(
+					`[JobService] ${isRetryableValidationFailure ? 'Retrying callback after validation failure' : 'Aborting callback to unsafe URL'}:`,
+					sanitizeCallbackUrlForLog(callbackUrl),
+				);
 				attempts.push({
 					attempt,
 					event: callbackEvent,

--- a/src/services/jobs/JobService.js
+++ b/src/services/jobs/JobService.js
@@ -69,6 +69,7 @@ function isPrivateIp(ip) {
 		if (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) return true; // RFC6598 shared address space
 		if (parts[0] === 169 && parts[1] === 254) return true; // Link-local (includes 169.254.169.254)
 		if (parts[0] === 198 && (parts[1] === 18 || parts[1] === 19)) return true; // Benchmarking
+		if (parts[0] === 192 && parts[1] === 0 && parts[2] === 2) return true; // Documentation
 		if (parts[0] === 198 && parts[1] === 51 && parts[2] === 100) return true; // Documentation
 		if (parts[0] === 203 && parts[1] === 0 && parts[2] === 113) return true; // Documentation
 		if (parts[0] >= 224 && parts[0] <= 239) return true; // Multicast

--- a/src/services/jobs/JobService.js
+++ b/src/services/jobs/JobService.js
@@ -2,6 +2,8 @@
 
 const crypto = require('crypto');
 const { v4: uuidv4 } = require('uuid');
+const dns = require('dns');
+const net = require('net');
 const { tradingViewMcpService } = require('../tradingview/TradingViewMcpService');
 const {
 	parseExpandedAnalysisAlertRequest,
@@ -28,20 +30,119 @@ const EXPIRATION_MS = 3600000; // 1 hour
 const DEFAULT_JOB_TIMEOUT_MS = 300000; // 5 minutes
 const TERMINAL_JOB_STATUSES = new Set(['completed', 'failed', 'cancelled', 'timed_out']);
 
-function isValidCallbackUrl(urlStr) {
+function expandIPv6(ip) {
+	let fullIp = ip;
+	if (ip.includes('::')) {
+		const parts = ip.split('::');
+		const left = parts[0] ? parts[0].split(':') : [];
+		const right = parts[1] ? parts[1].split(':') : [];
+		const missingCount = 8 - (left.length + right.length);
+		const middle = Array(missingCount).fill('0');
+		fullIp = [...left, ...middle, ...right].join(':');
+	}
+	return fullIp.split(':').map(part => part.padStart(4, '0')).join(':');
+}
+
+function isPrivateIp(ip) {
+	if (!ip) return true;
+	
+	let cleanIp = ip.trim().toLowerCase();
+	
+	// Handle IPv4-mapped IPv6 address like ::ffff:192.168.1.1
+	if (cleanIp.startsWith('::ffff:')) {
+		const ipv4Candidate = ip.substring(7);
+		if (net.isIPv4(ipv4Candidate)) {
+			cleanIp = ipv4Candidate;
+		}
+	}
+
+	if (net.isIPv4(cleanIp)) {
+		const parts = cleanIp.split('.').map(Number);
+		if (parts.length !== 4 || parts.some(isNaN)) return true;
+
+		if (parts[0] === 127) return true; // Loopback
+		if (parts[0] === 10) return true; // RFC1918
+		if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true; // RFC1918
+		if (parts[0] === 192 && parts[1] === 168) return true; // RFC1918
+		if (parts[0] === 169 && parts[1] === 254) return true; // Link-local (includes 169.254.169.254)
+		if (parts[0] >= 224 && parts[0] <= 239) return true; // Multicast
+		if (parts[0] === 0 && parts[1] === 0 && parts[2] === 0 && parts[3] === 0) return true;
+		if (parts[0] === 255 && parts[1] === 255 && parts[2] === 255 && parts[3] === 255) return true;
+
+		return false;
+	}
+
+	if (net.isIPv6(cleanIp)) {
+		const expanded = expandIPv6(cleanIp);
+
+		if (expanded === '0000:0000:0000:0000:0000:0000:0000:0001') return true; // Loopback
+		if (expanded === '0000:0000:0000:0000:0000:0000:0000:0000') return true; // Unspecified
+		if (/^fe[89ab]/i.test(expanded)) return true; // Link-local
+		if (/^f[cd]/i.test(expanded)) return true; // ULA
+		if (expanded.startsWith('ff')) return true; // Multicast
+
+		// Hex IPv4-mapped IPv6 address: ::ffff:7f00:0001
+		if (expanded.startsWith('0000:0000:0000:0000:0000:ffff:')) {
+			const parts = expanded.split(':');
+			const part6 = parts[6];
+			const part7 = parts[7];
+			
+			const octet0 = parseInt(part6.substring(0, 2), 16);
+			const octet1 = parseInt(part6.substring(2, 4), 16);
+			const octet2 = parseInt(part7.substring(0, 2), 16);
+			const octet3 = parseInt(part7.substring(2, 4), 16);
+			
+			const mappedIpv4 = `${octet0}.${octet1}.${octet2}.${octet3}`;
+			return isPrivateIp(mappedIpv4);
+		}
+
+		return false;
+	}
+
+	return true;
+}
+
+async function isValidCallbackUrl(urlStr) {
 	try {
 		const url = new URL(urlStr);
 		if (url.protocol !== 'http:' && url.protocol !== 'https:') {
 			return false;
 		}
+
+		const hostname = url.hostname;
+
 		if (url.protocol === 'http:') {
-			const isLocal = url.hostname === 'localhost' ||
-				url.hostname === '127.0.0.1' ||
-				url.hostname === '::1' ||
+			const isLocal = hostname === 'localhost' ||
+				hostname === '127.0.0.1' ||
+				hostname === '::1' ||
 				process.env.NODE_ENV === 'test' ||
 				process.env.ALLOW_HTTP_CALLBACKS === 'true';
 			return isLocal;
 		}
+
+		const allowPrivate = process.env.ALLOW_PRIVATE_CALLBACKS === 'true' ||
+			process.env.NODE_ENV === 'test';
+
+		if (allowPrivate) {
+			return true;
+		}
+
+		let ip;
+		if (net.isIP(hostname)) {
+			ip = hostname;
+		} else {
+			try {
+				const lookupRes = await dns.promises.lookup(hostname);
+				ip = lookupRes.address;
+			} catch (dnsErr) {
+				return false; // DNS resolution failed
+			}
+		}
+
+		if (isPrivateIp(ip)) {
+			return false;
+		}
+
 		return true;
 	} catch (err) {
 		return false;
@@ -210,7 +311,7 @@ class JobService {
 		let callbackEvents = ['completed', 'failed', 'cancelled', 'timed_out'];
 
 		if (payload && payload.callbackUrl !== undefined && payload.callbackUrl !== null) {
-			if (typeof payload.callbackUrl !== 'string' || !isValidCallbackUrl(payload.callbackUrl)) {
+			if (typeof payload.callbackUrl !== 'string' || !await isValidCallbackUrl(payload.callbackUrl)) {
 				const msg = 'callbackUrl must be a valid HTTPS URL (HTTP only allowed for local development)';
 				if (type === 'expanded-analysis') {
 					const { ExpandedAnalysisAlertRequestError } = require('../tradingview/expandedAnalysisAlertReport');
@@ -970,6 +1071,35 @@ class JobService {
 
 	async _sendCallbackWithRetry(job) {
 		const callbackUrl = job.callbackUrl;
+
+		if (!await isValidCallbackUrl(callbackUrl)) {
+			console.warn(`[JobService] Aborting callback to unsafe URL: ${callbackUrl}`);
+			const freshJob = await this.repository.get(job.jobId);
+			if (freshJob) {
+				const existingEvents = freshJob.callbackStatus?.events || {};
+				const timestamp = new Date().toISOString();
+				const attemptInfo = {
+					attempt: 1,
+					event: job.status,
+					timestamp,
+					error: 'Callback URL is blocked (private network)',
+				};
+				freshJob.callbackStatus = {
+					status: 'failed',
+					attempts: [attemptInfo],
+					events: {
+						...existingEvents,
+						[job.status]: {
+							status: 'failed',
+							attempts: [attemptInfo],
+						},
+					},
+				};
+				await this.repository.save(freshJob);
+			}
+			return;
+		}
+
 		const callbackEvent = job.status;
 		const secret = job.callbackSecret || process.env.JOB_CALLBACK_SIGNING_SECRET || '';
 		const payload = this._formatJobResponse(job);

--- a/src/services/jobs/JobService.js
+++ b/src/services/jobs/JobService.js
@@ -102,6 +102,13 @@ function isPrivateIp(ip) {
 	return true;
 }
 
+function normalizeHostname(hostname) {
+	if (hostname.startsWith('[') && hostname.endsWith(']')) {
+		return hostname.slice(1, -1);
+	}
+	return hostname;
+}
+
 async function isValidCallbackUrl(urlStr) {
 	try {
 		const url = new URL(urlStr);
@@ -109,7 +116,7 @@ async function isValidCallbackUrl(urlStr) {
 			return false;
 		}
 
-		const hostname = url.hostname;
+		const hostname = normalizeHostname(url.hostname);
 
 		if (url.protocol === 'http:') {
 			const isLocal = hostname === 'localhost' ||
@@ -127,19 +134,18 @@ async function isValidCallbackUrl(urlStr) {
 			return true;
 		}
 
-		let ip;
+		let addresses;
 		if (net.isIP(hostname)) {
-			ip = hostname;
+			addresses = [{ address: hostname }];
 		} else {
 			try {
-				const lookupRes = await dns.promises.lookup(hostname);
-				ip = lookupRes.address;
+				addresses = await dns.promises.lookup(hostname, { all: true, verbatim: true });
 			} catch (dnsErr) {
 				return false; // DNS resolution failed
 			}
 		}
 
-		if (isPrivateIp(ip)) {
+		if (!addresses.length || addresses.some(({ address }) => isPrivateIp(address))) {
 			return false;
 		}
 
@@ -1072,34 +1078,6 @@ class JobService {
 	async _sendCallbackWithRetry(job) {
 		const callbackUrl = job.callbackUrl;
 
-		if (!await isValidCallbackUrl(callbackUrl)) {
-			console.warn(`[JobService] Aborting callback to unsafe URL: ${callbackUrl}`);
-			const freshJob = await this.repository.get(job.jobId);
-			if (freshJob) {
-				const existingEvents = freshJob.callbackStatus?.events || {};
-				const timestamp = new Date().toISOString();
-				const attemptInfo = {
-					attempt: 1,
-					event: job.status,
-					timestamp,
-					error: 'Callback URL is blocked (private network)',
-				};
-				freshJob.callbackStatus = {
-					status: 'failed',
-					attempts: [attemptInfo],
-					events: {
-						...existingEvents,
-						[job.status]: {
-							status: 'failed',
-							attempts: [attemptInfo],
-						},
-					},
-				};
-				await this.repository.save(freshJob);
-			}
-			return;
-		}
-
 		const callbackEvent = job.status;
 		const secret = job.callbackSecret || process.env.JOB_CALLBACK_SIGNING_SECRET || '';
 		const payload = this._formatJobResponse(job);
@@ -1118,9 +1096,21 @@ class JobService {
 		let delayMs = process.env.JOB_CALLBACK_RETRY_DELAY_MS ? parseInt(process.env.JOB_CALLBACK_RETRY_DELAY_MS, 10) : 1000;
 
 		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+			const timestamp = new Date().toISOString();
+
+			if (!await isValidCallbackUrl(callbackUrl)) {
+				console.warn(`[JobService] Aborting callback to unsafe URL: ${callbackUrl}`);
+				attempts.push({
+					attempt,
+					event: callbackEvent,
+					timestamp,
+					error: 'Callback URL is blocked (private network)',
+				});
+				break;
+			}
+
 			const controller = new AbortController();
 			const timeoutId = setTimeout(() => controller.abort(), 5000);
-			const timestamp = new Date().toISOString();
 
 			try {
 				const response = await fetch(callbackUrl, {
@@ -1128,6 +1118,7 @@ class JobService {
 					headers,
 					body: payloadStr,
 					signal: controller.signal,
+					redirect: 'error',
 				});
 
 				clearTimeout(timeoutId);

--- a/src/services/jobs/JobService.js
+++ b/src/services/jobs/JobService.js
@@ -119,12 +119,14 @@ async function isValidCallbackUrl(urlStr) {
 		const hostname = normalizeHostname(url.hostname);
 
 		if (url.protocol === 'http:') {
-			const isLocal = hostname === 'localhost' ||
+			const httpAllowed = hostname === 'localhost' ||
 				hostname === '127.0.0.1' ||
 				hostname === '::1' ||
 				process.env.NODE_ENV === 'test' ||
 				process.env.ALLOW_HTTP_CALLBACKS === 'true';
-			return isLocal;
+			if (!httpAllowed) {
+				return false;
+			}
 		}
 
 		const allowPrivate = process.env.ALLOW_PRIVATE_CALLBACKS === 'true' ||

--- a/tests/integration/jobs-endpoint.test.js
+++ b/tests/integration/jobs-endpoint.test.js
@@ -338,5 +338,67 @@ describe('Jobs API Integration Tests', () => {
 				process.env.NODE_ENV = prevEnv;
 			}
 		});
+
+		it('returns 400 Bad Request if callbackUrl is a private network IP in production', async () => {
+			const prevEnv = process.env.NODE_ENV;
+			const prevAllow = process.env.ALLOW_HTTP_CALLBACKS;
+			const prevPrivate = process.env.ALLOW_PRIVATE_CALLBACKS;
+
+			process.env.NODE_ENV = 'production';
+			process.env.ALLOW_HTTP_CALLBACKS = 'false';
+			delete process.env.ALLOW_PRIVATE_CALLBACKS;
+
+			try {
+				const createRes = await request(app)
+					.post('/api/jobs/tradingview-analysis')
+					.set('x-api-key', 'test-key')
+					.send({
+						type: 'expanded-analysis',
+						symbols: ['BINANCE:BTCUSDT'],
+						callbackUrl: 'https://127.0.0.1/callback',
+					})
+					.expect(400);
+
+				expect(createRes.body.error).toContain('callbackUrl must be a valid HTTPS URL');
+			} finally {
+				process.env.NODE_ENV = prevEnv;
+				process.env.ALLOW_HTTP_CALLBACKS = prevAllow;
+				if (prevPrivate !== undefined) {
+					process.env.ALLOW_PRIVATE_CALLBACKS = prevPrivate;
+				} else {
+					delete process.env.ALLOW_PRIVATE_CALLBACKS;
+				}
+			}
+		});
+
+		it('allows private network callbackUrl if ALLOW_PRIVATE_CALLBACKS override is set', async () => {
+			const prevEnv = process.env.NODE_ENV;
+			const prevAllow = process.env.ALLOW_HTTP_CALLBACKS;
+			const prevPrivate = process.env.ALLOW_PRIVATE_CALLBACKS;
+
+			process.env.NODE_ENV = 'production';
+			process.env.ALLOW_HTTP_CALLBACKS = 'false';
+			process.env.ALLOW_PRIVATE_CALLBACKS = 'true';
+
+			try {
+				await request(app)
+					.post('/api/jobs/tradingview-analysis')
+					.set('x-api-key', 'test-key')
+					.send({
+						type: 'expanded-analysis',
+						symbols: ['BINANCE:BTCUSDT'],
+						callbackUrl: 'https://127.0.0.1/callback',
+					})
+					.expect(201);
+			} finally {
+				process.env.NODE_ENV = prevEnv;
+				process.env.ALLOW_HTTP_CALLBACKS = prevAllow;
+				if (prevPrivate !== undefined) {
+					process.env.ALLOW_PRIVATE_CALLBACKS = prevPrivate;
+				} else {
+					delete process.env.ALLOW_PRIVATE_CALLBACKS;
+				}
+			}
+		});
 	});
 });

--- a/tests/unit/job-service.test.js
+++ b/tests/unit/job-service.test.js
@@ -488,12 +488,22 @@ describe('JobService Unit Tests', () => {
 
 			beforeAll(() => {
 				const dns = require('dns');
-				dnsSpy = jest.spyOn(dns.promises, 'lookup').mockImplementation(async (hostname) => {
+				dnsSpy = jest.spyOn(dns.promises, 'lookup').mockImplementation(async (hostname, options) => {
 					if (hostname === 'example.com') {
-						return { address: '93.184.216.34' };
+						return options?.all
+							? [{ address: '93.184.216.34', family: 4 }]
+							: { address: '93.184.216.34', family: 4 };
 					}
 					if (hostname === 'localhost') {
-						return { address: '127.0.0.1' };
+						return options?.all
+							? [{ address: '127.0.0.1', family: 4 }]
+							: { address: '127.0.0.1', family: 4 };
+					}
+					if (hostname === 'mixed.example.com') {
+						return [
+							{ address: '93.184.216.34', family: 4 },
+							{ address: '169.254.169.254', family: 4 },
+						];
 					}
 					throw new Error('ENOTFOUND');
 				});
@@ -578,6 +588,32 @@ describe('JobService Unit Tests', () => {
 						delete process.env.ALLOW_PRIVATE_CALLBACKS;
 					}
 				}
+			});
+
+			it('rejects a hostname when any resolved address is private', async () => {
+				process.env.NODE_ENV = 'production';
+				delete process.env.ALLOW_PRIVATE_CALLBACKS;
+
+				await expect(jobService.createJob('expanded-analysis', {
+					symbols: ['BINANCE:BTCUSDT'],
+					callbackUrl: 'https://mixed.example.com/callback',
+				})).rejects.toThrow('callbackUrl must be a valid HTTPS URL');
+
+				expect(dnsSpy).toHaveBeenCalledWith('mixed.example.com', { all: true, verbatim: true });
+			});
+
+			it('accepts a public bracketed IPv6 literal without DNS lookup', async () => {
+				process.env.NODE_ENV = 'production';
+				delete process.env.ALLOW_PRIVATE_CALLBACKS;
+				dnsSpy.mockClear();
+
+				const result = await jobService.createJob('expanded-analysis', {
+					symbols: ['BINANCE:BTCUSDT'],
+					callbackUrl: 'https://[2606:4700:4700::1111]/callback',
+				});
+
+				expect(result.success).toBe(true);
+				expect(dnsSpy).not.toHaveBeenCalled();
 			});
 		});
 
@@ -702,6 +738,7 @@ describe('JobService Unit Tests', () => {
 			expect(url).toBe('https://example.com/callback');
 			expect(options.method).toBe('POST');
 			expect(options.headers['Content-Type']).toBe('application/json');
+			expect(options.redirect).toBe('error');
 
 			const body = JSON.parse(options.body);
 			expect(body.jobId).toBe(metadata.jobId);
@@ -713,6 +750,44 @@ describe('JobService Unit Tests', () => {
 			expect(freshJob.callbackStatus.status).toBe('success');
 			expect(freshJob.callbackStatus.attempts).toHaveLength(1);
 			expect(freshJob.callbackStatus.attempts[0].statusCode).toBe(200);
+		});
+
+		it('revalidates DNS before each retry and stops after rebinding to a private address', async () => {
+			const dns = require('dns');
+			const lookupSpy = jest.spyOn(dns.promises, 'lookup')
+				.mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }])
+				.mockResolvedValueOnce([{ address: '169.254.169.254', family: 4 }]);
+			process.env.NODE_ENV = 'production';
+			process.env.JOB_CALLBACK_RETRY_DELAY_MS = '1';
+			delete process.env.ALLOW_PRIVATE_CALLBACKS;
+			fetchMock.mockResolvedValue({ ok: false, status: 500, statusText: 'Server Error' });
+
+			const job = {
+				jobId: 'job-dns-rebinding',
+				type: 'expanded-analysis',
+				status: 'completed',
+				callbackUrl: 'https://rebind.example.com/callback',
+				callbackStatus: { status: 'pending', attempts: [] },
+				fullResults: [],
+				fullScanResults: [],
+				deliveryResults: [],
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			};
+			await jobService.repository.save(job);
+
+			try {
+				await jobService._sendCallbackWithRetry(job);
+
+				expect(fetchMock).toHaveBeenCalledTimes(1);
+				expect(lookupSpy).toHaveBeenCalledTimes(2);
+				const freshJob = await jobService.repository.get(job.jobId);
+				expect(freshJob.callbackStatus.status).toBe('failed');
+				expect(freshJob.callbackStatus.attempts).toHaveLength(2);
+				expect(freshJob.callbackStatus.attempts[1].error).toBe('Callback URL is blocked (private network)');
+			} finally {
+				lookupSpy.mockRestore();
+			}
 		});
 
 		it('signs payload with HMAC signature if callbackSecret is provided', async () => {

--- a/tests/unit/job-service.test.js
+++ b/tests/unit/job-service.test.js
@@ -532,6 +532,7 @@ describe('JobService Unit Tests', () => {
 						'https://10.0.0.1/callback',
 						'https://172.16.5.5/callback',
 						'https://192.168.1.100/callback',
+						'https://100.64.0.1/callback',
 						'https://169.254.169.254/callback',
 						'https://[fe80::1]/callback',
 						'https://[fc00::]/callback',
@@ -811,6 +812,49 @@ describe('JobService Unit Tests', () => {
 				expect(freshJob.callbackStatus.attempts).toHaveLength(2);
 				expect(freshJob.callbackStatus.attempts[1].error).toBe('Callback URL is blocked (private network)');
 			} finally {
+				lookupSpy.mockRestore();
+			}
+		});
+
+		it('retries delivery when DNS validation has a transient failure', async () => {
+			const dns = require('dns');
+			const lookupSpy = jest.spyOn(dns.promises, 'lookup')
+				.mockRejectedValueOnce(new Error('ENOTFOUND'))
+				.mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }]);
+			const prevEnv = process.env.NODE_ENV;
+			const prevDelay = process.env.JOB_CALLBACK_RETRY_DELAY_MS;
+			process.env.NODE_ENV = 'production';
+			process.env.JOB_CALLBACK_RETRY_DELAY_MS = '1';
+			delete process.env.ALLOW_PRIVATE_CALLBACKS;
+			fetchMock.mockResolvedValueOnce({ ok: true, status: 200 });
+
+			const job = {
+				jobId: 'job-transient-dns-failure',
+				type: 'expanded-analysis',
+				status: 'completed',
+				callbackUrl: 'https://flaky-dns.example.com/callback',
+				callbackStatus: { status: 'pending', attempts: [] },
+				fullResults: [],
+				fullScanResults: [],
+				deliveryResults: [],
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			};
+			await jobService.repository.save(job);
+
+			try {
+				await jobService._sendCallbackWithRetry(job);
+
+				expect(lookupSpy).toHaveBeenCalledTimes(2);
+				expect(fetchMock).toHaveBeenCalledTimes(1);
+				const freshJob = await jobService.repository.get(job.jobId);
+				expect(freshJob.callbackStatus.status).toBe('success');
+				expect(freshJob.callbackStatus.attempts).toHaveLength(2);
+				expect(freshJob.callbackStatus.attempts[0].error).toBe('Callback URL validation failed');
+				expect(freshJob.callbackStatus.attempts[1].statusCode).toBe(200);
+			} finally {
+				process.env.NODE_ENV = prevEnv;
+				process.env.JOB_CALLBACK_RETRY_DELAY_MS = prevDelay;
 				lookupSpy.mockRestore();
 			}
 		});

--- a/tests/unit/job-service.test.js
+++ b/tests/unit/job-service.test.js
@@ -532,6 +532,7 @@ describe('JobService Unit Tests', () => {
 						'https://[::1]/callback',
 						'https://10.0.0.1/callback',
 						'https://172.16.5.5/callback',
+						'https://192.0.0.8/callback',
 						'https://192.168.1.100/callback',
 						'https://100.64.0.1/callback',
 						'https://169.254.169.254/callback',
@@ -629,6 +630,18 @@ describe('JobService Unit Tests', () => {
 				})).rejects.toThrow('callbackUrl must be a valid HTTPS URL');
 
 				expect(dnsSpy).toHaveBeenCalledWith('mixed.example.com', { all: true, verbatim: true });
+			});
+
+			it('accepts public 192.0.0.0/16 addresses outside the IETF special-purpose /24', async () => {
+				process.env.NODE_ENV = 'production';
+				delete process.env.ALLOW_PRIVATE_CALLBACKS;
+
+				const result = await jobService.createJob('expanded-analysis', {
+					symbols: ['BINANCE:BTCUSDT'],
+					callbackUrl: 'https://192.0.3.1/callback',
+				});
+
+				expect(result.success).toBe(true);
 			});
 
 			it('accepts a public bracketed IPv6 literal without DNS lookup', async () => {

--- a/tests/unit/job-service.test.js
+++ b/tests/unit/job-service.test.js
@@ -526,6 +526,7 @@ describe('JobService Unit Tests', () => {
 
 				try {
 					const blockedUrls = [
+						'https://0.0.0.1/callback',
 						'https://localhost/callback',
 						'https://127.0.0.1/callback',
 						'https://[::1]/callback',
@@ -534,6 +535,8 @@ describe('JobService Unit Tests', () => {
 						'https://192.168.1.100/callback',
 						'https://100.64.0.1/callback',
 						'https://169.254.169.254/callback',
+						'https://198.18.0.1/callback',
+						'https://240.0.0.1/callback',
 						'https://[fe80::1]/callback',
 						'https://[fc00::]/callback',
 						'https://[ff02::1]/callback',
@@ -776,6 +779,67 @@ describe('JobService Unit Tests', () => {
 			expect(freshJob.callbackStatus.status).toBe('success');
 			expect(freshJob.callbackStatus.attempts).toHaveLength(1);
 			expect(freshJob.callbackStatus.attempts[0].statusCode).toBe(200);
+		});
+
+		it('sanitizes blocked callback URLs before logging delivery failures', async () => {
+			const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+			const prevEnv = process.env.NODE_ENV;
+			process.env.NODE_ENV = 'production';
+			delete process.env.ALLOW_PRIVATE_CALLBACKS;
+			const job = {
+				jobId: 'job-callback-blocked-log',
+				type: 'expanded-analysis',
+				status: 'completed',
+				requestMetadata: {
+					type: 'expanded-analysis',
+					symbols: ['BINANCE:BTCUSDT'],
+					timeframe: '1D',
+					includeMultiTimeframe: false,
+					analysisMode: 'standard',
+					timeoutMs: 300000,
+					callbackUrl: 'https://198.18.0.1/secret/path?token=super-secret',
+				},
+				progress: { total: 1, current: 1, status: 'completed' },
+				fullResults: [],
+				fullScanResults: [],
+				alertText: null,
+				deliveryResults: [],
+				summary: null,
+				error: null,
+				code: null,
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+				totalDurationMs: 0,
+				timeoutMs: 300000,
+				callbackUrl: 'https://198.18.0.1/secret/path?token=super-secret',
+				callbackStatus: { status: 'pending', attempts: [] },
+			};
+
+			await jobService.repository.save(job);
+			try {
+				await jobService._triggerCallbackIfConfigured(job);
+
+				let freshJob = await jobService.repository.get(job.jobId);
+				let pollAttempts = 0;
+				while ((!freshJob.callbackStatus || freshJob.callbackStatus.status === 'pending') && pollAttempts < 20) {
+					await delay(20);
+					freshJob = await jobService.repository.get(job.jobId);
+					pollAttempts++;
+				}
+
+				expect(fetchMock).not.toHaveBeenCalled();
+				expect(freshJob.callbackStatus.status).toBe('failed');
+				expect(warnSpy).toHaveBeenCalledWith(
+					expect.stringContaining('Aborting callback to unsafe URL'),
+					'https://198.18.0.1/...',
+				);
+				const loggedText = warnSpy.mock.calls.flat().join(' ');
+				expect(loggedText).not.toContain('super-secret');
+				expect(loggedText).not.toContain('/secret/path');
+			} finally {
+				process.env.NODE_ENV = prevEnv;
+				warnSpy.mockRestore();
+			}
 		});
 
 		it('revalidates DNS before each retry and stops after rebinding to a private address', async () => {

--- a/tests/unit/job-service.test.js
+++ b/tests/unit/job-service.test.js
@@ -469,9 +469,9 @@ describe('JobService Unit Tests', () => {
 			}
 		});
 
-		it('allows http for localhost / local environments', async () => {
+		it('allows http for localhost in local environments', async () => {
 			const prevEnv = process.env.NODE_ENV;
-			process.env.NODE_ENV = 'production';
+			process.env.NODE_ENV = 'test';
 			try {
 				const res = await jobService.createJob('expanded-analysis', {
 					symbols: ['BINANCE:BTCUSDT'],
@@ -553,6 +553,31 @@ describe('JobService Unit Tests', () => {
 						callbackUrl: 'https://example.com/callback',
 					});
 					expect(successRes.success).toBe(true);
+				} finally {
+					process.env.NODE_ENV = prevEnv;
+					process.env.ALLOW_HTTP_CALLBACKS = prevAllow;
+					if (prevPrivate !== undefined) {
+						process.env.ALLOW_PRIVATE_CALLBACKS = prevPrivate;
+					} else {
+						delete process.env.ALLOW_PRIVATE_CALLBACKS;
+					}
+				}
+			});
+
+			it('rejects private HTTP callback URLs even when HTTP callbacks are enabled', async () => {
+				const prevEnv = process.env.NODE_ENV;
+				const prevAllow = process.env.ALLOW_HTTP_CALLBACKS;
+				const prevPrivate = process.env.ALLOW_PRIVATE_CALLBACKS;
+
+				process.env.NODE_ENV = 'production';
+				process.env.ALLOW_HTTP_CALLBACKS = 'true';
+				delete process.env.ALLOW_PRIVATE_CALLBACKS;
+
+				try {
+					await expect(jobService.createJob('expanded-analysis', {
+						symbols: ['BINANCE:BTCUSDT'],
+						callbackUrl: 'http://169.254.169.254/callback',
+					})).rejects.toThrow('callbackUrl must be a valid HTTPS URL');
 				} finally {
 					process.env.NODE_ENV = prevEnv;
 					process.env.ALLOW_HTTP_CALLBACKS = prevAllow;

--- a/tests/unit/job-service.test.js
+++ b/tests/unit/job-service.test.js
@@ -533,6 +533,7 @@ describe('JobService Unit Tests', () => {
 						'https://10.0.0.1/callback',
 						'https://172.16.5.5/callback',
 						'https://192.0.0.8/callback',
+						'https://192.0.2.1/callback',
 						'https://192.168.1.100/callback',
 						'https://100.64.0.1/callback',
 						'https://169.254.169.254/callback',

--- a/tests/unit/job-service.test.js
+++ b/tests/unit/job-service.test.js
@@ -483,6 +483,104 @@ describe('JobService Unit Tests', () => {
 			}
 		});
 
+		describe('private-network blocking (SSRF protection)', () => {
+			let dnsSpy;
+
+			beforeAll(() => {
+				const dns = require('dns');
+				dnsSpy = jest.spyOn(dns.promises, 'lookup').mockImplementation(async (hostname) => {
+					if (hostname === 'example.com') {
+						return { address: '93.184.216.34' };
+					}
+					if (hostname === 'localhost') {
+						return { address: '127.0.0.1' };
+					}
+					throw new Error('ENOTFOUND');
+				});
+			});
+
+			afterAll(() => {
+				if (dnsSpy) {
+					dnsSpy.mockRestore();
+				}
+			});
+
+			it('rejects loopback, link-local, RFC1918, multicast, and metadata-service callback URLs in production', async () => {
+				const prevEnv = process.env.NODE_ENV;
+				const prevAllow = process.env.ALLOW_HTTP_CALLBACKS;
+				const prevPrivate = process.env.ALLOW_PRIVATE_CALLBACKS;
+
+				process.env.NODE_ENV = 'production';
+				process.env.ALLOW_HTTP_CALLBACKS = 'false';
+				delete process.env.ALLOW_PRIVATE_CALLBACKS;
+
+				try {
+					const blockedUrls = [
+						'https://localhost/callback',
+						'https://127.0.0.1/callback',
+						'https://[::1]/callback',
+						'https://10.0.0.1/callback',
+						'https://172.16.5.5/callback',
+						'https://192.168.1.100/callback',
+						'https://169.254.169.254/callback',
+						'https://[fe80::1]/callback',
+						'https://[fc00::]/callback',
+						'https://[ff02::1]/callback',
+						'https://[::ffff:127.0.0.1]/callback',
+						'https://[::ffff:7f00:0001]/callback',
+					];
+
+					for (const urlStr of blockedUrls) {
+						await expect(jobService.createJob('expanded-analysis', {
+							symbols: ['BINANCE:BTCUSDT'],
+							callbackUrl: urlStr,
+						})).rejects.toThrow('callbackUrl must be a valid HTTPS URL');
+					}
+
+					// Verify a public URL passes
+					const successRes = await jobService.createJob('expanded-analysis', {
+						symbols: ['BINANCE:BTCUSDT'],
+						callbackUrl: 'https://example.com/callback',
+					});
+					expect(successRes.success).toBe(true);
+				} finally {
+					process.env.NODE_ENV = prevEnv;
+					process.env.ALLOW_HTTP_CALLBACKS = prevAllow;
+					if (prevPrivate !== undefined) {
+						process.env.ALLOW_PRIVATE_CALLBACKS = prevPrivate;
+					} else {
+						delete process.env.ALLOW_PRIVATE_CALLBACKS;
+					}
+				}
+			});
+
+			it('allows private-network callback URLs if ALLOW_PRIVATE_CALLBACKS override is set', async () => {
+				const prevEnv = process.env.NODE_ENV;
+				const prevAllow = process.env.ALLOW_HTTP_CALLBACKS;
+				const prevPrivate = process.env.ALLOW_PRIVATE_CALLBACKS;
+
+				process.env.NODE_ENV = 'production';
+				process.env.ALLOW_HTTP_CALLBACKS = 'false';
+				process.env.ALLOW_PRIVATE_CALLBACKS = 'true';
+
+				try {
+					const res = await jobService.createJob('expanded-analysis', {
+						symbols: ['BINANCE:BTCUSDT'],
+						callbackUrl: 'https://127.0.0.1/callback',
+					});
+					expect(res.success).toBe(true);
+				} finally {
+					process.env.NODE_ENV = prevEnv;
+					process.env.ALLOW_HTTP_CALLBACKS = prevAllow;
+					if (prevPrivate !== undefined) {
+						process.env.ALLOW_PRIVATE_CALLBACKS = prevPrivate;
+					} else {
+						delete process.env.ALLOW_PRIVATE_CALLBACKS;
+					}
+				}
+			});
+		});
+
 		it('validates callbackSecret is a string', async () => {
 			await expect(jobService.createJob('expanded-analysis', {
 				symbols: ['BINANCE:BTCUSDT'],


### PR DESCRIPTION
## Summary

Hardens async job callback delivery against private-network SSRF while preserving the existing callback API and local-development overrides.

## Key Changes

- Rejects loopback, link-local, RFC1918, multicast, metadata-service, and private IPv6 callback targets.
- Resolves and validates every DNS answer instead of trusting one address.
- Normalizes bracketed IPv6 literals before IP classification.
- Revalidates callback targets before every retry and disables automatic redirects.
- Documents the callback security behavior and Postman invalid-request example.

## Technical Implementation

Callback URL validation remains fail-safe and uses Node.js native DNS, IP, and `fetch` APIs. Delivery failures are recorded in per-event callback status without crashing the job worker.

## Testing

- `pnpm test -- tests/unit/job-service.test.js --runInBand`
- `pnpm test -- tests/integration/jobs-endpoint.test.js --runInBand`
- `pnpm test`

## References

- Fixes #152
- **Linear**: [CB-55](https://linear.app/knil/issue/CB-55/block-private-network-callback-urls-for-async-jobs)
