### PR TITLE
feat: enable TradingView confluence enrichment by default (CB-56)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,7 +116,7 @@ TRADINGVIEW_MCP_DEFAULT_TIMEFRAME=1h
 ENABLE_TRADINGVIEW_VOLUME_CONFIRMATION=false
 
 # Enable combined_analysis confluence enrichment for TradingView webhook alerts (default: false)
-ENABLE_TRADINGVIEW_CONFLUENCE_ENRICHMENT=false
+ENABLE_TRADINGVIEW_CONFLUENCE_ENRICHMENT=true
 
 # Also call multi_timeframe_analysis during confluence enrichment (default: false)
 ENABLE_TRADINGVIEW_CONFLUENCE_MULTI_TIMEFRAME=false

--- a/src/controllers/status.js
+++ b/src/controllers/status.js
@@ -294,7 +294,7 @@ function getStatus() {
 			geminiGrounding: geminiGroundingEnabled,
 			newsMonitor: newsMonitorEnabled,
 			tradingViewMcpEnrichment: tradingViewMcpEnrichmentEnabled,
-			tradingViewConfluenceEnrichment: isEnabled(process.env.ENABLE_TRADINGVIEW_CONFLUENCE_ENRICHMENT),
+			tradingViewConfluenceEnrichment: process.env.ENABLE_TRADINGVIEW_CONFLUENCE_ENRICHMENT !== 'false',
 			tradingViewConfluenceMultiTimeframe: isEnabled(process.env.ENABLE_TRADINGVIEW_CONFLUENCE_MULTI_TIMEFRAME),
 			firestoreAlertStorage: firestoreEnabled,
 			sentryMonitoring: sentryEnabled,

--- a/src/services/tradingview/TradingViewMcpService.js
+++ b/src/services/tradingview/TradingViewMcpService.js
@@ -134,7 +134,7 @@ class TradingViewMcpService {
 		// (via AbortSignal.any) so an exhausted enrichment budget cancels it immediately.
 		let confluenceAnalysis = null;
 		let multiTimeframeAnalysis = null;
-		if (process.env.ENABLE_TRADINGVIEW_CONFLUENCE_ENRICHMENT === 'true' && !budgetController.signal.aborted) {
+		if (process.env.ENABLE_TRADINGVIEW_CONFLUENCE_ENRICHMENT !== 'false' && !budgetController.signal.aborted) {
 			const confluenceTimeoutMs = Math.min(8000, Math.max(2000, (budgetMs || 12000) / 2));
 			const confluenceController = new AbortController();
 			const confluenceTimeoutId = setTimeout(() => {


### PR DESCRIPTION
feat: enable TradingView confluence enrichment by default (CB-56)

**Summary**

Flip the `ENABLE_TRADINGVIEW_CONFLUENCE_ENRICHMENT` gate from opt-in (`=== 'true'`) to enabled-by-default (`!== 'false'`). The TradingView MCP service is already ready in production (`dependencies.tradingViewMcp.status=ready`), and the confluence enrichment path (`combined_analysis`) is fail-open — errors log a warning and do not block delivery. Enabling this by default activates the confluence analysis for enriched webhook alerts without requiring manual env var configuration.

**Key Changes**

- **`src/services/tradingview/TradingViewMcpService.js:137`** — Change gate from `=== 'true'` to `!== 'false'`, enabling confluence enrichment by default. Operators can still disable it by setting `ENABLE_TRADINGVIEW_CONFLUENCE_ENRICHMENT=false`.
- **`src/controllers/status.js:297`** — Update the `tradingViewConfluenceEnrichment` feature flag in `/api/capabilities` to reflect the new default logic (`!== 'false'`).
- **`.env.example:119`** — Update default to `true` to match the code behavior.

**Technical Implementation**

The confluence enrichment (TradingView MCP `combined_analysis` call) was previously gated on `=== 'true'`, defaulting to `false` when the env var was unset. Since the conditional is now `!== 'false'`, the default becomes `true` — the feature activates on any deployment that does not explicitly disable it. The `status.js` `tradingViewConfluenceEnrichment` flag is updated with inline logic instead of using the shared `isEnabled()` helper (which still returns `value === 'true'` for all other flags).

The existing fail-open behavior is unaffected: if the `combined_analysis` call fails, it logs a warning and continues without blocking alert delivery.

**Testing**

All 874 existing tests pass. No behavioral change was introduced to existing tests because the tests set env vars explicitly (they already control their own test environment).

**References**

- **Linear**: [CB-56](https://linear.app/knil/issue/CB-56/enable-tradingview-confluence-enrichment-in-production)
- GitHub issue #167