### PR TITLE
fix(storage): replace stale news claims (CB-63)

### DIFF
--- a/src/services/storage/NewsDedupStorageService.js
+++ b/src/services/storage/NewsDedupStorageService.js
@@ -131,7 +131,7 @@ async function getEntry(key) {
 }
 
 /**
- * Claim a dedup entry atomically using DocumentReference.create().
+ * Claim a dedup entry atomically, replacing it only when its TTL has expired.
  *
  * @param {string} key - Dedup key
  * @param {number} ttlMs - TTL in milliseconds
@@ -144,30 +144,33 @@ async function claimEntry(key, ttlMs) {
 	}
 
 	try {
-		// First verify if a valid non-expired entry exists
-		const existing = await getEntry(key);
-		if (existing) {
-			return false;
-		}
-
 		const now = admin.firestore.Timestamp.now();
 		const expiresAtMs = now.toMillis() + ttlMs;
 		const expiresAt = admin.firestore.Timestamp.fromMillis(expiresAtMs);
-
 		const docRef = firestore.collection(COLLECTION_NAME).doc(key);
-		await docRef.create({
-			key,
-			createdAt: now,
-			expiresAt,
-			data: { status: 'claiming' },
+		const claimed = await firestore.runTransaction(async transaction => {
+			const existing = await transaction.get(docRef);
+			const existingData = existing.exists && existing.data();
+
+			if (existing.exists && (!existingData?.expiresAt || existingData.expiresAt.toMillis() > now.toMillis())) {
+				return false;
+			}
+
+			transaction.set(docRef, {
+				key,
+				createdAt: now,
+				expiresAt,
+				data: { status: 'claiming' },
+			});
+			return true;
 		});
-		console.debug('[NewsDedupStorageService] Dedup entry claimed:', key);
-		return true;
-	} catch (error) {
-		if (error.code === 6 || error.message.includes('ALREADY_EXISTS')) {
+		if (!claimed) {
 			console.debug('[NewsDedupStorageService] Dedup entry already exists during claim:', key);
 			return false;
 		}
+		console.debug('[NewsDedupStorageService] Dedup entry claimed:', key);
+		return true;
+	} catch (error) {
 		console.warn('[NewsDedupStorageService] claimEntry error (fail-open):', error.message);
 		// Fail-open: allow claim to succeed so the replica can alert
 		return true;
@@ -251,4 +254,3 @@ module.exports = {
 		db = null;
 	},
 };
-

--- a/src/services/storage/NewsDedupStorageService.js
+++ b/src/services/storage/NewsDedupStorageService.js
@@ -152,7 +152,8 @@ async function claimEntry(key, ttlMs) {
 			const existing = await transaction.get(docRef);
 			const existingData = existing.exists && existing.data();
 
-			if (existing.exists && (!existingData?.expiresAt || existingData.expiresAt.toMillis() > now.toMillis())) {
+			if (existing.exists && (typeof existingData?.expiresAt?.toMillis !== 'function'
+				|| existingData.expiresAt.toMillis() > now.toMillis())) {
 				return false;
 			}
 

--- a/tests/unit/news-monitor-persistent-dedup.test.js
+++ b/tests/unit/news-monitor-persistent-dedup.test.js
@@ -13,6 +13,7 @@ const mockGetEntry = jest.fn().mockResolvedValue(null);
 const mockClaimEntry = jest.fn().mockResolvedValue(true);
 const mockSetEntry = jest.fn().mockResolvedValue(undefined);
 const mockDeleteEntry = jest.fn().mockResolvedValue(undefined);
+const admin = require('firebase-admin');
 
 jest.mock('../../src/services/storage/NewsDedupStorageService', () => ({
 	isEnabled: mockIsEnabled,
@@ -306,5 +307,52 @@ describe('NewsDedupStorageService — isEnabled()', () => {
 		process.env.ENABLE_NEWS_MONITOR_PERSISTENT_DEDUP = 'true';
 		const realService = jest.requireActual('../../src/services/storage/NewsDedupStorageService');
 		expect(realService.isEnabled()).toBe(true);
+	});
+});
+
+describe('NewsDedupStorageService — claimEntry()', () => {
+	const originalNow = admin.firestore.Timestamp.now;
+	const originalFromMillis = admin.firestore.Timestamp.fromMillis;
+
+	afterEach(() => {
+		jest.clearAllMocks();
+		admin.firestore.mockClear();
+		admin.firestore.Timestamp.now = originalNow;
+		admin.firestore.Timestamp.fromMillis = originalFromMillis;
+		delete process.env.ENABLE_NEWS_MONITOR_PERSISTENT_DEDUP;
+	});
+
+	it('replaces an expired Firestore claim atomically', async () => {
+		process.env.ENABLE_NEWS_MONITOR_PERSISTENT_DEDUP = 'true';
+		const now = { toMillis: () => 10_000 };
+		const expiresAt = { toMillis: () => 15_000 };
+		const docRef = {};
+		const transaction = {
+			get: jest.fn().mockResolvedValue({
+				exists: true,
+				data: () => ({ expiresAt: { toMillis: () => 9_999 } }),
+			}),
+			set: jest.fn(),
+		};
+		const runTransaction = jest.fn(async callback => callback(transaction));
+
+		admin.firestore.mockReturnValue({
+			collection: () => ({ doc: () => docRef }),
+			runTransaction,
+		});
+		admin.firestore.Timestamp.now = jest.fn(() => now);
+		admin.firestore.Timestamp.fromMillis = jest.fn(() => expiresAt);
+
+		const realService = jest.requireActual('../../src/services/storage/NewsDedupStorageService');
+		realService._resetForTesting();
+
+		await expect(realService.claimEntry('BTCUSDT:price_surge', 5_000)).resolves.toBe(true);
+		expect(runTransaction).toHaveBeenCalledTimes(1);
+		expect(transaction.set).toHaveBeenCalledWith(docRef, {
+			key: 'BTCUSDT:price_surge',
+			createdAt: now,
+			expiresAt,
+			data: { status: 'claiming' },
+		});
 	});
 });

--- a/tests/unit/news-monitor-persistent-dedup.test.js
+++ b/tests/unit/news-monitor-persistent-dedup.test.js
@@ -355,4 +355,29 @@ describe('NewsDedupStorageService — claimEntry()', () => {
 			data: { status: 'claiming' },
 		});
 	});
+
+	it('treats a malformed existing expiry as an already claimed entry', async () => {
+		process.env.ENABLE_NEWS_MONITOR_PERSISTENT_DEDUP = 'true';
+		const transaction = {
+			get: jest.fn().mockResolvedValue({
+				exists: true,
+				data: () => ({ expiresAt: 'invalid' }),
+			}),
+			set: jest.fn(),
+		};
+		const runTransaction = jest.fn(async callback => callback(transaction));
+
+		admin.firestore.mockReturnValue({
+			collection: () => ({ doc: () => ({}) }),
+			runTransaction,
+		});
+		admin.firestore.Timestamp.now = jest.fn(() => ({ toMillis: () => 10_000 }));
+		admin.firestore.Timestamp.fromMillis = jest.fn(() => ({ toMillis: () => 15_000 }));
+
+		const realService = jest.requireActual('../../src/services/storage/NewsDedupStorageService');
+		realService._resetForTesting();
+
+		await expect(realService.claimEntry('BTCUSDT:price_surge', 5_000)).resolves.toBe(false);
+		expect(transaction.set).not.toHaveBeenCalled();
+	});
 });

--- a/tests/unit/tradingview-mcp-service.test.js
+++ b/tests/unit/tradingview-mcp-service.test.js
@@ -13,6 +13,7 @@ describe('TradingViewMcpService', () => {
 	});
 
 	it('maps new coin_analysis schema into webhook enriched alert', async () => {
+		process.env.ENABLE_TRADINGVIEW_CONFLUENCE_ENRICHMENT = 'false';
 		const service = new TradingViewMcpService({
 			maxRetries: 1,
 			defaultExchange: 'BINANCE',


### PR DESCRIPTION
# fix(storage): replace stale news claims (CB-63)

## Summary

Atomically replace expired Firestore news dedup claims so a valid alert after the TTL is not suppressed by a stale document.

## Key Changes

### :zap: Atomic dedup claims

- Read and write the dedup document in one Firestore transaction.
- Preserve duplicate handling for valid and malformed existing documents.
- Keep Firestore failures fail-open for notification delivery.

## Testing

- `pnpm test -- tests/unit/news-monitor-persistent-dedup.test.js --runInBand`
- `pnpm test`

## References

- GitHub issue: https://github.com/francovp/cabros-bot/issues/156
- **Linear**: [CB-63](https://linear.app/knil/issue/CB-63/allow-expired-news-dedup-claims-to-replace-stale-firestore-docs)
