### PR TITLE
fix: preserve non-gemini token usage (CB-78)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -729,6 +729,7 @@ See `/specs/TERMINOLOGY_GUIDE.md` for extended discussion and examples.
 - shadow-mode-outcome-tracking (CB-42 / Issue #129): Added shadow-mode outcome tracking for alert-producing surfaces (webhook alerts, market scanner breakouts/gains/losses, expanded-analysis, news alerts). Normalizes signal metadata (requestId, source, symbol, exchange, timeframe, setupType, score, side, price, etc.) and periodically evaluates outcomes over +1h, +4h, +1D, and +1W windows using Binance historical candlestick data. Exposes aggregated metrics under `shadowModeMetrics` inside `GET /api/alerts/summary` and in custom header `X-Shadow-Mode-Metrics` inside `GET /api/alerts/export`.
 - GH-178 / CB-74: `ENABLE_SIGNAL_OUTCOME_TRACKING` is the canonical signal-outcome gate; `ENABLE_SHADOW_MODE_OUTCOME_TRACKING` remains a one-release compatibility alias, and `/api/capabilities` reports the effective gate.
 - GH-182 / CB-77: malformed or no-domain grounding sources count toward the declared UNKNOWN `0.5` quality tier instead of contributing zero; regression coverage lives in `tests/unit/event-detection.test.js`.
+- GH-183 / CB-78: Azure, OpenRouter, and Cloudflare `llmCallv2()` results now return normalized token usage for downstream `tokenUsage` aggregation; the shared normalizer accepts OpenAI-compatible `prompt_tokens`, `completion_tokens`, and `total_tokens` fields.
 
 ## Architectural Patterns & Extension Guide
 

--- a/src/lib/tokenUsage.js
+++ b/src/lib/tokenUsage.js
@@ -33,7 +33,8 @@ const PRICING_PER_1M = {
 
 /**
  * Normalize usage metadata from various providers into a common shape.
- * Supports Gemini usageMetadata ({ promptTokenCount, candidatesTokenCount, totalTokenCount })
+ * Supports Gemini usageMetadata ({ promptTokenCount, candidatesTokenCount, totalTokenCount }),
+ * OpenAI-compatible usage ({ prompt_tokens, completion_tokens, total_tokens }),
  * and generic { inputTokens, outputTokens, totalTokens } objects.
  * @param {Object} usageMetadata
  * @returns {{ inputTokens: number, outputTokens: number, totalTokens: number }|null}
@@ -42,10 +43,10 @@ function normalizeUsageMetadata(usageMetadata) {
 	if (!usageMetadata) return null;
 
 	const meta = usageMetadata.usageMetadata || usageMetadata;
-	const inputTokens = toNumber(firstDefined(meta.promptTokenCount, meta.inputTokens, meta.promptTokens)) || 0;
-	const outputTokens = toNumber(firstDefined(meta.candidatesTokenCount, meta.outputTokens, meta.completionTokens)) || 0;
+	const inputTokens = toNumber(firstDefined(meta.promptTokenCount, meta.inputTokens, meta.promptTokens, meta.prompt_tokens)) || 0;
+	const outputTokens = toNumber(firstDefined(meta.candidatesTokenCount, meta.outputTokens, meta.completionTokens, meta.completion_tokens)) || 0;
 
-	const explicitTotal = toNumber(firstDefined(meta.totalTokenCount, meta.totalTokens));
+	const explicitTotal = toNumber(firstDefined(meta.totalTokenCount, meta.totalTokens, meta.total_tokens));
 	const totalTokens = explicitTotal != null ? explicitTotal : inputTokens + outputTokens;
 
 	return {

--- a/src/services/grounding/genaiClient.js
+++ b/src/services/grounding/genaiClient.js
@@ -400,6 +400,7 @@ class GenaiClient {
 					return {
 						text,
 						citations: context.citations || [],
+						usage: usageNorm,
 						modelUsed: AZURE_LLM_MODEL || 'azure-llm',
 					};
 				} else {
@@ -425,6 +426,7 @@ class GenaiClient {
 					return {
 						text,
 						citations: context.citations || [],
+						usage: usageNorm,
 						modelUsed: OPENROUTER_MODEL || 'openrouter-model',
 					};
 				} else {
@@ -450,6 +452,7 @@ class GenaiClient {
 					return {
 						text,
 						citations: context.citations || [],
+						usage: usageNorm,
 						modelUsed: CF_AIG_MODEL || 'cloudflare-aig',
 					};
 				} else {

--- a/tests/unit/gemini-client.test.js
+++ b/tests/unit/gemini-client.test.js
@@ -73,6 +73,24 @@ describe('Gemini Service', () => {
 			// sources are not returned by generateEnrichedAlert
 		});
 
+		it('adds provider usage returned by llmCallv2 to the token tracker', async () => {
+			const tokenUsage = { addUsage: jest.fn() };
+			const usage = { inputTokens: 11, outputTokens: 22, totalTokens: 33 };
+			genaiClient.llmCallv2.mockResolvedValue({
+				text: JSON.stringify(mockEnrichedResponse),
+				usage,
+				modelUsed: 'gpt-4o-mini',
+			});
+
+			await generateEnrichedAlert({
+				text: 'Bitcoin breaks 83k after a volatile session',
+				searchResults: mockSearchResults,
+				options: { tokenUsage },
+			});
+
+			expect(tokenUsage.addUsage).toHaveBeenCalledWith(usage, 'gpt-4o-mini');
+		});
+
 		it('retries with the fallback Gemini model on transient 500 INTERNAL errors', async () => {
 			genaiClient.llmCallv2
 				.mockRejectedValueOnce(Object.assign(

--- a/tests/unit/genai-client-provider-normalization.test.js
+++ b/tests/unit/genai-client-provider-normalization.test.js
@@ -23,7 +23,7 @@ describe('GenaiClient provider normalization', () => {
 			validate: jest.fn().mockReturnValue(true),
 			chatCompletion: jest.fn().mockResolvedValue({
 				text: 'azure response',
-				usage: {},
+				usage: { prompt_tokens: 11, completion_tokens: 22, total_tokens: 33 },
 			}),
 		};
 
@@ -54,5 +54,46 @@ describe('GenaiClient provider normalization', () => {
 		expect(mockAzureClient.chatCompletion).toHaveBeenCalledWith('system', 'user');
 		expect(result.text).toBe('azure response');
 		expect(result.modelUsed).toBe('gpt-4o-mini');
+		expect(result.usage).toEqual({ inputTokens: 11, outputTokens: 22, totalTokens: 33 });
+	});
+
+	it.each([
+		['openrouter', 'OPENROUTER_API_KEY', 'OPENROUTER_MODEL', 'openrouter-model'],
+		['cloudflare', 'CF_AIG_TOKEN', 'CF_AIG_MODEL', 'cloudflare-model'],
+	])('returns normalized usage from the %s provider', async (provider, key, modelKey, model) => {
+		process.env.MODEL_PROVIDER = provider;
+		process.env[key] = 'provider-key';
+		process.env[modelKey] = model;
+
+		const mockProviderClient = {
+			validate: jest.fn().mockReturnValue(true),
+			chatCompletion: jest.fn().mockResolvedValue({
+				text: `${provider} response`,
+				usage: { prompt_tokens: 7, completion_tokens: 13, total_tokens: 20 },
+			}),
+		};
+
+		jest.doMock('@google/genai', () => ({
+			GoogleGenAI: jest.fn(() => ({ models: { generateContent: jest.fn() } })),
+		}));
+		jest.doMock('../../src/services/inference/azureAiClient', () => ({
+			getAzureAIClient: jest.fn(() => ({ validate: jest.fn().mockReturnValue(false) })),
+		}));
+		jest.doMock('../../src/services/inference/openRouterClient', () => ({
+			getOpenRouterClient: jest.fn(() => mockProviderClient),
+		}));
+		jest.doMock('../../src/services/inference/cloudflareAiClient', () => ({
+			getCloudflareAiClient: jest.fn(() => mockProviderClient),
+		}));
+
+		const genaiClient = require('../../src/services/grounding/genaiClient');
+		const result = await genaiClient.llmCallv2({ systemPrompt: 'system', userPrompt: 'user' });
+
+		expect(mockProviderClient.chatCompletion).toHaveBeenCalledWith('system', 'user');
+		expect(result).toEqual(expect.objectContaining({
+			text: `${provider} response`,
+			modelUsed: model,
+			usage: { inputTokens: 7, outputTokens: 13, totalTokens: 20 },
+		}));
 	});
 });


### PR DESCRIPTION
## Summary

Preserve token usage from Azure, OpenRouter, and Cloudflare LLM calls so existing response and storage aggregation reports non-Gemini usage.

## Key Changes

- Return normalized `usage` from each non-Gemini `llmCallv2()` provider branch.
- Extend shared token metadata normalization for OpenAI-compatible snake_case fields.
- Add provider-routing and enrichment token-tracking regression coverage.

## Technical Implementation

`llmCallv2()` already normalized provider usage for Sentry metrics but discarded that value from its return object. The same normalized value is now returned to the existing `gemini.js` token tracker. `normalizeUsageMetadata()` accepts `prompt_tokens`, `completion_tokens`, and `total_tokens` alongside existing Gemini and camelCase formats.

## Testing

- `pnpm test -- tests/unit/genai-client-provider-normalization.test.js tests/unit/gemini-client.test.js --runInBand`
- `pnpm test` — 70 suites, 944 tests passed
- `git diff --check`

## References

- GitHub issue: https://github.com/francovp/cabros-bot/issues/183
- **Linear**: [CB-78](https://linear.app/knil/issue/CB-78/return-token-usage-from-non-gemini-llm-providers-gh-183)
