### PR TITLE
test: cover shadow-mode storage gate (CB-81)

### DIFF
--- a/tests/unit/alert-storage-service.test.js
+++ b/tests/unit/alert-storage-service.test.js
@@ -200,6 +200,15 @@ describe('AlertStorageService', () => {
 			expect(mockAdd).not.toHaveBeenCalled();
 		});
 
+		it('does not save alerts when only legacy shadow-mode tracking is enabled', async () => {
+			process.env.ENABLE_SHADOW_MODE_OUTCOME_TRACKING = 'true';
+
+			const result = await AlertStorageService.saveAlert(buildParams());
+
+			expect(result).toBeNull();
+			expect(mockAdd).not.toHaveBeenCalled();
+		});
+
 		it('calls collection("alerts").add() with correctly shaped document', async () => {
 			process.env.ENABLE_FIRESTORE_ALERT_STORAGE = 'true';
 			const docId = 'abc123';


### PR DESCRIPTION
## Summary

Add explicit regression coverage proving legacy shadow-mode tracking does not persist webhook alerts unless alert storage is independently enabled.

## Key Changes

- Extend `tests/unit/alert-storage-service.test.js` with the legacy `ENABLE_SHADOW_MODE_OUTCOME_TRACKING`-only case.
- Confirm `saveAlert()` returns `null` and never calls Firestore `add()` under that configuration.

## Technical Implementation

The production guard was already shipped in merged PR #206; this branch closes the remaining test-coverage gap for the compatibility alias without changing runtime behavior.

## Testing

- `pnpm test -- tests/unit/alert-storage-service.test.js --runInBand` — 40/40 passed.

## References

- Fixes #197
- GitHub issue: https://github.com/francovp/cabros-bot/issues/197
- Linear: https://linear.app/knil/issue/CB-81/gate-alert-persistence-independently-from-shadow-tracking
- Existing production guard: https://github.com/francovp/cabros-bot/pull/206