### PR TITLE
feat: retry Discord 429 webhook deliveries within a bounded budget (CB-95)

### DIFF
--- a/src/services/notification/DiscordService.js
+++ b/src/services/notification/DiscordService.js
@@ -4,6 +4,20 @@ const { splitMessageIntoChunks } = require('../../lib/messageHelper');
 
 const DEFAULT_TIMEOUT_MS = 10000;
 const DISCORD_MESSAGE_LIMIT = 2000;
+const DEFAULT_MAX_RETRIES = 2;
+const DEFAULT_FALLBACK_RETRY_DELAY_MS = 500;
+const DEFAULT_MAX_RETRY_DELAY_MS = 5000;
+const DEFAULT_MAX_TOTAL_RETRY_WAIT_MS = 10000;
+
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseEnvInt(envVar, defaultValue) {
+	if (!process.env[envVar]) return defaultValue;
+	const val = parseInt(process.env[envVar], 10);
+	return Number.isNaN(val) ? defaultValue : val;
+}
 
 class DiscordService extends NotificationChannel {
 	constructor(config = {}) {
@@ -14,6 +28,10 @@ class DiscordService extends NotificationChannel {
 		this.logger = config.logger;
 		this.formatter = config.formatter || new WhatsAppMarkdownFormatter();
 		this.enabled = false;
+		this.maxRetries = config.maxRetries ?? parseEnvInt('DISCORD_MAX_RETRIES', DEFAULT_MAX_RETRIES);
+		this.fallbackRetryDelayMs = config.fallbackRetryDelayMs ?? parseEnvInt('DISCORD_FALLBACK_RETRY_DELAY_MS', DEFAULT_FALLBACK_RETRY_DELAY_MS);
+		this.maxRetryDelayMs = config.maxRetryDelayMs ?? parseEnvInt('DISCORD_MAX_RETRY_DELAY_MS', DEFAULT_MAX_RETRY_DELAY_MS);
+		this.maxTotalRetryWaitMs = config.maxTotalRetryWaitMs ?? parseEnvInt('DISCORD_MAX_TOTAL_RETRY_WAIT_MS', DEFAULT_MAX_TOTAL_RETRY_WAIT_MS);
 	}
 
 	async validate() {
@@ -80,47 +98,139 @@ class DiscordService extends NotificationChannel {
 		return typeof alert.text === 'string' ? alert.text : '';
 	}
 
-	async sendChunk(content) {
-		const controller = new AbortController();
-		const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
-
-		try {
-			const response = await fetch(this.getExecutionUrl(), {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ content }),
-				signal: controller.signal,
-			});
-
-			if (!response.ok) {
-				const errorText = await response.text();
-				return {
-					success: false,
-					channel: 'discord',
-					error: `Discord webhook ${response.status}: ${errorText}`,
-					statusCode: response.status,
-				};
+	extractRetryAfterMs(response, bodyText) {
+		let retryHeader = null;
+		if (response && response.headers) {
+			if (typeof response.headers.get === 'function') {
+				retryHeader = response.headers.get('retry-after') || response.headers.get('Retry-After');
+			} else if (typeof response.headers === 'object') {
+				retryHeader = response.headers['retry-after'] || response.headers['Retry-After'];
 			}
-
-			const data = await response.json();
-			return {
-				success: true,
-				channel: 'discord',
-				messageId: data.id || 'discord-webhook',
-			};
-		} catch (error) {
-			if (error && error.name === 'AbortError') {
-				return {
-					success: false,
-					channel: 'discord',
-					error: 'Discord webhook request timeout',
-				};
-			}
-
-			throw error;
-		} finally {
-			clearTimeout(timeoutId);
 		}
+
+		if (retryHeader) {
+			const parsed = parseFloat(retryHeader);
+			if (!Number.isNaN(parsed) && parsed > 0) {
+				return parsed < 500 ? Math.round(parsed * 1000) : Math.round(parsed);
+			}
+			const dateMs = Date.parse(retryHeader);
+			if (!Number.isNaN(dateMs)) {
+				const diffMs = dateMs - Date.now();
+				if (diffMs > 0) {
+					return Math.round(diffMs);
+				}
+			}
+		}
+
+		if (bodyText) {
+			try {
+				const json = JSON.parse(bodyText);
+				const val = json.retry_after ?? json.retryAfter;
+				if (typeof val === 'number' && val > 0) {
+					return val < 500 ? Math.round(val * 1000) : Math.round(val);
+				}
+				if (typeof val === 'string') {
+					const parsed = parseFloat(val);
+					if (!Number.isNaN(parsed) && parsed > 0) {
+						return parsed < 500 ? Math.round(parsed * 1000) : Math.round(parsed);
+					}
+				}
+			} catch (_) {
+				// Ignore non-JSON body
+			}
+		}
+
+		return this.fallbackRetryDelayMs;
+	}
+
+	async sendChunk(content) {
+		let attempt = 0;
+		let totalWaitMs = 0;
+
+		while (attempt <= this.maxRetries) {
+			attempt++;
+			const controller = new AbortController();
+			const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+
+			try {
+				const response = await fetch(this.getExecutionUrl(), {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ content }),
+					signal: controller.signal,
+				});
+
+				if (response.ok) {
+					const data = await response.json();
+					return {
+						success: true,
+						channel: 'discord',
+						messageId: data.id || 'discord-webhook',
+					};
+				}
+
+				const errorText = await response.text();
+
+				if (response.status !== 429) {
+					return {
+						success: false,
+						channel: 'discord',
+						error: `Discord webhook ${response.status}: ${errorText}`,
+						statusCode: response.status,
+					};
+				}
+
+				if (attempt > this.maxRetries) {
+					return {
+						success: false,
+						channel: 'discord',
+						error: `Discord webhook 429: ${errorText}`,
+						statusCode: 429,
+					};
+				}
+
+				const rawDelayMs = this.extractRetryAfterMs(response, errorText);
+				const effectiveDelayMs = Math.min(rawDelayMs, this.maxRetryDelayMs);
+
+				if (totalWaitMs + effectiveDelayMs > this.maxTotalRetryWaitMs) {
+					this.logger?.warn?.(
+						`Discord 429 retry delay (${effectiveDelayMs}ms) exceeds remaining total wait budget (${this.maxTotalRetryWaitMs - totalWaitMs}ms). Aborting retries.`,
+					);
+					return {
+						success: false,
+						channel: 'discord',
+						error: `Discord webhook 429: ${errorText}`,
+						statusCode: 429,
+					};
+				}
+
+				this.logger?.warn?.(
+					`Discord webhook rate limited (429). Retrying in ${effectiveDelayMs}ms (attempt ${attempt}/${this.maxRetries + 1})...`,
+				);
+
+				await sleep(effectiveDelayMs);
+				totalWaitMs += effectiveDelayMs;
+			} catch (error) {
+				if (error && error.name === 'AbortError') {
+					return {
+						success: false,
+						channel: 'discord',
+						error: 'Discord webhook request timeout',
+					};
+				}
+
+				throw error;
+			} finally {
+				clearTimeout(timeoutId);
+			}
+		}
+
+		return {
+			success: false,
+			channel: 'discord',
+			error: 'Discord webhook 429 retries exhausted',
+			statusCode: 429,
+		};
 	}
 }
 

--- a/tests/integration/graceful-degradation.test.js
+++ b/tests/integration/graceful-degradation.test.js
@@ -5,6 +5,7 @@
 
 const TelegramService = require('../../src/services/notification/TelegramService');
 const WhatsAppService = require('../../src/services/notification/WhatsAppService');
+const DiscordService = require('../../src/services/notification/DiscordService');
 const NotificationManager = require('../../src/services/notification/NotificationManager');
 
 describe('Graceful Degradation & Fallback', () => {
@@ -207,6 +208,47 @@ describe('Graceful Degradation & Fallback', () => {
 			results.forEach((r) => {
 				expect(r.success).toBe(true);
 			});
+		});
+	});
+
+	describe('Test 7: Discord 429 rate limit retries in multi-channel setup', () => {
+		it('should retry Discord 429 while Telegram succeeds, completing fail-open multi-channel delivery', async () => {
+			process.env.ENABLE_DISCORD_ALERTS = 'true';
+			process.env.DISCORD_WEBHOOK_URL = 'https://discord.com/api/webhooks/test/token';
+
+			const telegramService = new TelegramService({ bot: mockBot });
+			const whatsappService = new WhatsAppService();
+			const discordService = new DiscordService({
+				maxRetries: 2,
+				maxRetryDelayMs: 500,
+				maxTotalRetryWaitMs: 1000,
+			});
+			const notificationManager = new NotificationManager(telegramService, whatsappService, discordService);
+
+			await notificationManager.validateAll();
+
+			global.fetch = jest.fn()
+				.mockResolvedValueOnce({
+					ok: false,
+					status: 429,
+					headers: new Map([['retry-after', '0.01']]),
+					text: async () => 'rate limited',
+				})
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => ({ id: 'discord-multichannel-ok' }),
+				});
+
+			const results = await notificationManager.sendToAll({ text: 'Multi-channel alert' });
+
+			expect(results).toHaveLength(2);
+			const tgResult = results.find((r) => r.channel === 'telegram');
+			const discordResult = results.find((r) => r.channel === 'discord');
+
+			expect(tgResult.success).toBe(true);
+			expect(discordResult.success).toBe(true);
+			expect(discordResult.messageId).toBe('discord-multichannel-ok');
+			expect(global.fetch).toHaveBeenCalledTimes(2);
 		});
 	});
 });

--- a/tests/unit/discord-service.test.js
+++ b/tests/unit/discord-service.test.js
@@ -86,7 +86,7 @@ describe('DiscordService', () => {
 			);
 		});
 
-		it('returns a failed result when the webhook responds with an error', async () => {
+		it('returns a failed result when the webhook responds with a non-429 error', async () => {
 			global.fetch.mockResolvedValue({
 				ok: false,
 				status: 400,
@@ -98,6 +98,156 @@ describe('DiscordService', () => {
 			expect(result.success).toBe(false);
 			expect(result.channel).toBe('discord');
 			expect(result.error).toContain('Discord webhook 400');
+			expect(global.fetch).toHaveBeenCalledTimes(1);
+		});
+
+		it('retries on HTTP 429 when Retry-After header is provided and succeeds on subsequent attempt', async () => {
+			service = new DiscordService({
+				logger: mockLogger,
+				maxRetries: 2,
+				maxRetryDelayMs: 1000,
+				maxTotalRetryWaitMs: 2000,
+			});
+			await service.validate();
+
+			const headers = new Map([['retry-after', '0.01']]);
+			global.fetch = jest.fn()
+				.mockResolvedValueOnce({
+					ok: false,
+					status: 429,
+					headers,
+					text: async () => 'rate limited header',
+				})
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => ({ id: 'discord-msg-retried' }),
+				});
+
+			const result = await service.send({ text: 'Discord alert' });
+
+			expect(result).toEqual({
+				success: true,
+				channel: 'discord',
+				messageId: 'discord-msg-retried',
+				messageIds: ['discord-msg-retried'],
+				messageCount: 1,
+			});
+			expect(global.fetch).toHaveBeenCalledTimes(2);
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('429'),
+			);
+		});
+
+		it('retries on HTTP 429 when retry_after JSON body is provided', async () => {
+			service = new DiscordService({
+				logger: mockLogger,
+				maxRetries: 2,
+				maxRetryDelayMs: 1000,
+				maxTotalRetryWaitMs: 2000,
+			});
+			await service.validate();
+
+			global.fetch = jest.fn()
+				.mockResolvedValueOnce({
+					ok: false,
+					status: 429,
+					headers: new Map(),
+					text: async () => JSON.stringify({ message: 'You are being rate limited.', retry_after: 0.01 }),
+				})
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => ({ id: 'discord-msg-body-retried' }),
+				});
+
+			const result = await service.send({ text: 'Discord alert' });
+
+			expect(result).toEqual({
+				success: true,
+				channel: 'discord',
+				messageId: 'discord-msg-body-retried',
+				messageIds: ['discord-msg-body-retried'],
+				messageCount: 1,
+			});
+			expect(global.fetch).toHaveBeenCalledTimes(2);
+		});
+
+		it('fails gracefully when HTTP 429 retries are exhausted', async () => {
+			service = new DiscordService({
+				logger: mockLogger,
+				maxRetries: 2,
+				maxRetryDelayMs: 1000,
+				maxTotalRetryWaitMs: 2000,
+			});
+			await service.validate();
+
+			global.fetch = jest.fn().mockResolvedValue({
+				ok: false,
+				status: 429,
+				headers: new Map([['retry-after', '0.01']]),
+				text: async () => 'rate limited repeatedly',
+			});
+
+			const result = await service.send({ text: 'Discord alert' });
+
+			expect(result.success).toBe(false);
+			expect(result.channel).toBe('discord');
+			expect(result.statusCode).toBe(429);
+			expect(result.error).toContain('Discord webhook 429');
+			// Initial attempt + 2 retries = 3 total fetch calls
+			expect(global.fetch).toHaveBeenCalledTimes(3);
+		});
+
+		it('uses fallback delay when 429 retry hints are missing or malformed', async () => {
+			service = new DiscordService({
+				logger: mockLogger,
+				maxRetries: 1,
+				fallbackRetryDelayMs: 10,
+				maxRetryDelayMs: 1000,
+				maxTotalRetryWaitMs: 2000,
+			});
+			await service.validate();
+
+			global.fetch = jest.fn()
+				.mockResolvedValueOnce({
+					ok: false,
+					status: 429,
+					headers: new Map(),
+					text: async () => 'not json',
+				})
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => ({ id: 'discord-msg-fallback-ok' }),
+				});
+
+			const result = await service.send({ text: 'Discord alert' });
+
+			expect(result.success).toBe(true);
+			expect(result.messageId).toBe('discord-msg-fallback-ok');
+			expect(global.fetch).toHaveBeenCalledTimes(2);
+		});
+
+		it('aborts retry loop if retry delay exceeds max total wait budget', async () => {
+			service = new DiscordService({
+				logger: mockLogger,
+				maxRetries: 3,
+				maxRetryDelayMs: 10000,
+				maxTotalRetryWaitMs: 50,
+			});
+			await service.validate();
+
+			const headers = new Map([['retry-after', '5']]); // 5 seconds = 5000ms > maxTotalRetryWaitMs (50ms)
+			global.fetch = jest.fn().mockResolvedValue({
+				ok: false,
+				status: 429,
+				headers,
+				text: async () => 'huge delay rate limit',
+			});
+
+			const result = await service.send({ text: 'Discord alert' });
+
+			expect(result.success).toBe(false);
+			expect(result.statusCode).toBe(429);
+			expect(global.fetch).toHaveBeenCalledTimes(1);
 		});
 
 		it('returns a failed result when the webhook request times out', async () => {


### PR DESCRIPTION
feat: retry Discord 429 webhook deliveries within a bounded budget (CB-95)

## Summary

This PR addresses degraded production delivery telemetry on Discord caused by provider rate limiting (`429`). When Discord webhooks return HTTP `429`, `DiscordService.sendChunk()` now parses the retry delay from either the `Retry-After` header or the JSON `retry_after` payload, applies a bounded retry count (default 2) and wait budget (default 10s max total wait, 5s max per delay), and retries the failed chunk. If retries are exhausted or delay budget is exceeded, it returns a structured failure without blocking Telegram or WhatsApp alerts.

## Key Changes

- **Discord HTTP 429 Retry Handling**: Implemented bounded retry loop in `DiscordService.sendChunk()` for HTTP `429` responses.
- **Retry Delay Parsing**: Added `extractRetryAfterMs()` to parse `Retry-After` header (numeric seconds/ms or HTTP date) and JSON `retry_after`/`retryAfter` body hints, falling back to 500ms when hints are absent or malformed.
- **Budget & Delay Safety**: Capped individual retry delays to `maxRetryDelayMs` (5s default) and total retry wait time to `maxTotalRetryWaitMs` (10s default).
- **Fail-Open Isolation**: Preserved channel isolation so rate-limited Discord chunks return a structured error result when retries fail, ensuring Telegram and WhatsApp alert deliveries are never blocked.
- **Environment & Config Overrides**: Supported `DISCORD_MAX_RETRIES`, `DISCORD_FALLBACK_RETRY_DELAY_MS`, `DISCORD_MAX_RETRY_DELAY_MS`, and `DISCORD_MAX_TOTAL_RETRY_WAIT_MS` env vars.

## Technical Implementation

- Updated `src/services/notification/DiscordService.js` to iterate up to `maxRetries` per chunk on status `429`.
- Non-429 HTTP errors and `AbortError` timeouts retain their existing behavior.
- Added structured logging (`logger.warn`) when rate limiting occurs and when retries are attempted or aborted.

## Testing

- **Unit Tests**: Updated `tests/unit/discord-service.test.js` with comprehensive 429 scenarios:
  - Header `Retry-After` parsing & successful retry.
  - JSON body `retry_after` parsing & successful retry.
  - Exhausted retries after `maxRetries` returning structured failure.
  - Budget limit abort when delay exceeds `maxTotalRetryWaitMs`.
  - Fallback delay when retry hints are malformed or missing.
  - Verification that non-429 errors and timeouts do not trigger retries.
- **Integration Tests**: Added Test 7 to `tests/integration/graceful-degradation.test.js` verifying that Discord 429 retries operate correctly alongside Telegram delivery in multi-channel configurations.

## References

- **Linear**: [CB-95](https://linear.app/knil/issue/CB-95/retry-discord-429-webhook-deliveries-within-a-bounded-fail)
- Fixes #237
