### PR TITLE
feat: make asynchronous TradingView job starts idempotent (CB-96)

### DIFF
--- a/CabrosBot.postman_collection.json
+++ b/CabrosBot.postman_collection.json
@@ -1746,6 +1746,12 @@
                 "key": "x-api-key",
                 "value": "{{apiKey}}",
                 "type": "text"
+              },
+              {
+                "key": "idempotency-key",
+                "value": "{{jobIdempotencyKey}}",
+                "type": "text",
+                "disabled": true
               }
             ],
             "body": {

--- a/src/openapi/openapi.json
+++ b/src/openapi/openapi.json
@@ -144,8 +144,9 @@
     "/api/jobs/tradingview-analysis": {
       "post": {
         "tags": ["Jobs"], "summary": "Create an asynchronous TradingView job", "operationId": "createTradingViewJob",
+        "parameters": [{ "$ref": "#/components/parameters/IdempotencyKey" }],
         "requestBody": { "$ref": "#/components/requestBodies/TradingViewJob" },
-        "responses": { "201": { "$ref": "#/components/responses/JobResult" }, "400": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
+        "responses": { "201": { "$ref": "#/components/responses/JobResult" }, "400": { "$ref": "#/components/responses/Error" }, "409": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
         "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
       }
     },
@@ -176,7 +177,7 @@
     "/api/jobs/{jobId}/retry": {
       "post": {
         "tags": ["Jobs"], "summary": "Retry a failed job", "operationId": "retryJob",
-        "parameters": [{ "$ref": "#/components/parameters/JobId" }],
+        "parameters": [{ "$ref": "#/components/parameters/JobId" }, { "$ref": "#/components/parameters/IdempotencyKey" }],
         "responses": { "201": { "$ref": "#/components/responses/JobResult" }, "404": { "$ref": "#/components/responses/Error" }, "409": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
         "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
       }
@@ -184,7 +185,7 @@
     "/api/jobs/{jobId}/retry-failed": {
       "post": {
         "tags": ["Jobs"], "summary": "Retry failed items in a completed job", "operationId": "retryFailedJobItems",
-        "parameters": [{ "$ref": "#/components/parameters/JobId" }],
+        "parameters": [{ "$ref": "#/components/parameters/JobId" }, { "$ref": "#/components/parameters/IdempotencyKey" }],
         "responses": { "201": { "$ref": "#/components/responses/JobResult" }, "400": { "$ref": "#/components/responses/Error" }, "404": { "$ref": "#/components/responses/Error" }, "409": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
         "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
       }
@@ -224,6 +225,7 @@
       "ApiKeyQuery": { "type": "apiKey", "in": "query", "name": "api-key", "description": "Legacy compatibility only. Prefer x-api-key because query strings may be logged." }
     },
     "parameters": {
+      "IdempotencyKey": { "name": "idempotency-key", "in": "header", "schema": { "type": "string" }, "description": "Optional idempotency key to prevent duplicate processing on retries." },
       "AlertId": { "name": "alertId", "in": "path", "required": true, "schema": { "type": "string" }, "example": "alert-123" },
       "PresetId": { "name": "id", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } },
       "JobId": { "name": "jobId", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } },

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -45,12 +45,12 @@ function getRoutes(botOrGetter) {
 	router.post('/scanner-presets/:id/run', validateApiKey, postRunPreset(botOrGetter));
 
 	// Async job endpoints
-	router.post('/jobs/tradingview-analysis', validateApiKey, postCreateJob(botOrGetter));
+	router.post('/jobs/tradingview-analysis', validateApiKey, idempotencyMiddleware, postCreateJob(botOrGetter));
 	router.get('/jobs', validateApiKey, getJobList);
 	router.get('/jobs/:jobId', validateApiKey, getJobStatus);
 	router.post('/jobs/:jobId/cancel', validateApiKey, postCancelJob);
-	router.post('/jobs/:jobId/retry', validateApiKey, postRetryJob(botOrGetter));
-	router.post('/jobs/:jobId/retry-failed', validateApiKey, postRetryFailedJob(botOrGetter));
+	router.post('/jobs/:jobId/retry', validateApiKey, idempotencyMiddleware, postRetryJob(botOrGetter));
+	router.post('/jobs/:jobId/retry-failed', validateApiKey, idempotencyMiddleware, postRetryFailedJob(botOrGetter));
 
 	const { getNewsMonitor } = require('../controllers/webhooks/handlers/newsMonitor/newsMonitor');
 	const newsMonitor = getNewsMonitor();

--- a/tests/integration/jobs-endpoint.test.js
+++ b/tests/integration/jobs-endpoint.test.js
@@ -8,6 +8,7 @@ const { initializeNotificationServices } = require('../../src/controllers/webhoo
 const { tradingViewMcpService } = require('../../src/services/tradingview/TradingViewMcpService');
 const { jobRepository, _resetForTesting: resetJobRepository } = require('../../src/services/jobs/JobRepository');
 const alertStorageService = require('../../src/services/storage/AlertStorageService');
+const { idempotencyService } = require('../../src/services/storage/IdempotencyService');
 
 jest.mock('../../src/services/tradingview/TradingViewMcpService', () => ({
 	tradingViewMcpService: {
@@ -35,6 +36,7 @@ describe('Jobs API Integration Tests', () => {
 		};
 
 		jest.clearAllMocks();
+		idempotencyService.clear();
 		admin.__resetCollectionState();
 		alertStorageService._resetForTesting();
 		resetJobRepository();
@@ -555,6 +557,160 @@ describe('Jobs API Integration Tests', () => {
 					delete process.env.ALLOW_PRIVATE_CALLBACKS;
 				}
 			}
+		});
+	});
+
+	describe('Idempotent job start contract', () => {
+		it('replays job creation response with stable jobId on sequential retries with same idempotency key', async () => {
+			tradingViewMcpService.analyzeSymbolIdentifier.mockResolvedValue({
+				symbol: 'BINANCE:BTCUSDT',
+				price_data: { close: 65000 },
+			});
+
+			const key = 'job-creation-key-1';
+			const jobBody = {
+				type: 'expanded-analysis',
+				symbols: ['BINANCE:BTCUSDT'],
+			};
+
+			// Initial creation
+			const res1 = await request(app)
+				.post('/api/jobs/tradingview-analysis')
+				.set('x-api-key', 'test-key')
+				.set('idempotency-key', key)
+				.send(jobBody)
+				.expect(201);
+
+			expect(res1.headers['idempotency-replay']).toBe('false');
+			expect(res1.body.success).toBe(true);
+			const originalJobId = res1.body.jobId;
+			expect(originalJobId).toBeDefined();
+
+			// Sequential retry with same key and body
+			const res2 = await request(app)
+				.post('/api/jobs/tradingview-analysis')
+				.set('x-api-key', 'test-key')
+				.set('idempotency-key', key)
+				.send(jobBody)
+				.expect(201);
+
+			expect(res2.headers['idempotency-replay']).toBe('true');
+			expect(res2.body.success).toBe(true);
+			expect(res2.body.jobId).toBe(originalJobId);
+			expect(res2.body.idempotencyReplayed).toBe(true);
+		});
+
+		it('deduplicates concurrent in-flight job creation requests with same idempotency key', async () => {
+			tradingViewMcpService.analyzeSymbolIdentifier.mockImplementation(
+				() => new Promise((resolve) => setTimeout(() => resolve({ symbol: 'BINANCE:BTCUSDT' }), 50)),
+			);
+
+			const key = 'job-concurrent-key';
+			const jobBody = { type: 'expanded-analysis', symbols: ['BINANCE:BTCUSDT'] };
+
+			const [res1, res2] = await Promise.all([
+				request(app)
+					.post('/api/jobs/tradingview-analysis')
+					.set('x-api-key', 'test-key')
+					.set('idempotency-key', key)
+					.send(jobBody),
+				request(app)
+					.post('/api/jobs/tradingview-analysis')
+					.set('x-api-key', 'test-key')
+					.set('idempotency-key', key)
+					.send(jobBody),
+			]);
+
+			expect(res1.status).toBe(201);
+			expect(res2.status).toBe(201);
+			expect(res1.body.jobId).toBe(res2.body.jobId);
+
+			const replayFlags = [res1.headers['idempotency-replay'], res2.headers['idempotency-replay']];
+			expect(replayFlags).toContain('false');
+			expect(replayFlags).toContain('true');
+		});
+
+		it('returns 409 IDEMPOTENCY_CONFLICT when key is reused with a different request fingerprint', async () => {
+			const key = 'job-conflict-key';
+
+			await request(app)
+				.post('/api/jobs/tradingview-analysis')
+				.set('x-api-key', 'test-key')
+				.set('idempotency-key', key)
+				.send({ type: 'expanded-analysis', symbols: ['BINANCE:BTCUSDT'] })
+				.expect(201);
+
+			const conflictRes = await request(app)
+				.post('/api/jobs/tradingview-analysis')
+				.set('x-api-key', 'test-key')
+				.set('idempotency-key', key)
+				.send({ type: 'expanded-analysis', symbols: ['BINANCE:ETHUSDT'] })
+				.expect(409);
+
+			expect(conflictRes.body.code).toBe('IDEMPOTENCY_CONFLICT');
+			expect(conflictRes.body.error).toContain('reused with a different payload');
+		});
+
+		it('replays job retry and retry-failed responses on matching idempotency keys', async () => {
+			tradingViewMcpService.analyzeSymbolIdentifier.mockImplementation(
+				() => new Promise((resolve) => setTimeout(resolve, 200)),
+			);
+
+			// Create job and cancel it to make it retryable
+			const createRes = await request(app)
+				.post('/api/jobs/tradingview-analysis')
+				.set('x-api-key', 'test-key')
+				.send({ type: 'expanded-analysis', symbols: ['BINANCE:BTCUSDT'] })
+				.expect(201);
+
+			const jobId = createRes.body.jobId;
+			await request(app)
+				.post(`/api/jobs/${jobId}/cancel`)
+				.set('x-api-key', 'test-key')
+				.expect(200);
+
+			// Retry with idempotency key
+			const retryKey = 'retry-idem-key';
+			const retry1 = await request(app)
+				.post(`/api/jobs/${jobId}/retry`)
+				.set('x-api-key', 'test-key')
+				.set('idempotency-key', retryKey)
+				.expect(201);
+
+			expect(retry1.headers['idempotency-replay']).toBe('false');
+			expect(retry1.body.oldJobId).toBe(jobId);
+			const newJobId = retry1.body.newJobId;
+
+			// Repeat retry with same key
+			const retry2 = await request(app)
+				.post(`/api/jobs/${jobId}/retry`)
+				.set('x-api-key', 'test-key')
+				.set('idempotency-key', retryKey)
+				.expect(201);
+
+			expect(retry2.headers['idempotency-replay']).toBe('true');
+			expect(retry2.body.newJobId).toBe(newJobId);
+			expect(retry2.body.idempotencyReplayed).toBe(true);
+		});
+
+		it('retains default behavior for requests without an idempotency key', async () => {
+			tradingViewMcpService.analyzeSymbolIdentifier.mockResolvedValue({ symbol: 'BINANCE:BTCUSDT' });
+
+			const res1 = await request(app)
+				.post('/api/jobs/tradingview-analysis')
+				.set('x-api-key', 'test-key')
+				.send({ type: 'expanded-analysis', symbols: ['BINANCE:BTCUSDT'] })
+				.expect(201);
+
+			const res2 = await request(app)
+				.post('/api/jobs/tradingview-analysis')
+				.set('x-api-key', 'test-key')
+				.send({ type: 'expanded-analysis', symbols: ['BINANCE:BTCUSDT'] })
+				.expect(201);
+
+			expect(res1.body.jobId).not.toBe(res2.body.jobId);
+			expect(res1.headers['idempotency-replay']).toBeUndefined();
+			expect(res2.headers['idempotency-replay']).toBeUndefined();
 		});
 	});
 });


### PR DESCRIPTION
feat: make asynchronous TradingView job starts idempotent (CB-96)

## Summary

Extends the existing `idempotencyMiddleware` contract to asynchronous TradingView job-starting operations (`POST /api/jobs/tradingview-analysis`, `POST /api/jobs/:jobId/retry`, and `POST /api/jobs/:jobId/retry-failed`). Retried job-start requests using the same `Idempotency-Key` and matching payload replay the initial `201 Created` response (including the original `jobId`) without launching redundant background workers.

## Key Changes

- **Routes**: Attached `idempotencyMiddleware` to `/api/jobs/tradingview-analysis`, `/api/jobs/:jobId/retry`, and `/api/jobs/:jobId/retry-failed` in `src/routes/index.js`.
- **Integration Tests**: Added `Idempotent job start contract` suite in `tests/integration/jobs-endpoint.test.js` covering initial creation replay, in-flight deduplication, 409 conflict detection, retry/retry-failed replay, and un-keyed request fallback.
- **OpenAPI**: Documented `IdempotencyKey` parameter and `409` Conflict responses in `src/openapi/openapi.json`.
- **Postman**: Added optional `idempotency-key` header to `POST /api/jobs/tradingview-analysis` in `CabrosBot.postman_collection.json`.

## Technical Implementation

Reuses `idempotencyMiddleware` from `src/lib/idempotency.js` and `idempotencyService` from `src/services/storage/IdempotencyService.js`. When an idempotency key is provided via header, body, or query:
1. First-time requests execute normally and cache successful (<500) response payloads.
2. Matching retries set `Idempotency-Replay: true` header and replay cached responses.
3. In-flight concurrent requests queue until completion and receive the single generated `jobId`.
4. Fingerprint mismatches trigger `409 IDEMPOTENCY_CONFLICT`.

## Testing

- `pnpm test -- tests/integration/jobs-endpoint.test.js` (20/20 passed)
- `pnpm test -- tests/unit/idempotency.test.js` (25/25 passed)

## References

- **GitHub Issue**: [#239](https://github.com/francovp/cabros-bot/issues/239)
- **Linear**: [CB-96](https://linear.app/knil/issue/CB-96/gh-239-make-asynchronous-tradingview-job-starts-idempotent)
