### PR TITLE
feat: make generic-message delivery idempotent to prevent duplicate notifications (CB-97)

### DIFF
--- a/CabrosBot.postman_collection.json
+++ b/CabrosBot.postman_collection.json
@@ -691,6 +691,24 @@
               "status": "Unauthorized",
               "code": 401,
               "body": "{\n  \"error\": \"Unauthorized: Missing API key\"\n}"
+            },
+            {
+              "name": "Success (replayed response)",
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Idempotency-Replay",
+                  "value": "true"
+                }
+              ],
+              "body": "{\n  \"success\": true,\n  \"results\": [\n    {\n      \"channel\": \"telegram\",\n      \"success\": true,\n      \"messageId\": \"tg-msg-123\",\n      \"attemptCount\": 1,\n      \"durationMs\": 450\n    }\n  ],\n  \"idempotencyReplayed\": true\n}"
+            },
+            {
+              "name": "Conflict (idempotency key reused)",
+              "status": "Conflict",
+              "code": 409,
+              "body": "{\n  \"error\": \"Idempotency key was reused with a different payload\",\n  \"code\": \"IDEMPOTENCY_CONFLICT\"\n}"
             }
           ]
         }

--- a/src/openapi/openapi.json
+++ b/src/openapi/openapi.json
@@ -27,8 +27,9 @@
     "/api/webhook/message": {
       "post": {
         "tags": ["Webhooks"], "summary": "Deliver a generic message", "operationId": "postMessage",
+        "parameters": [{ "$ref": "#/components/parameters/IdempotencyKey" }],
         "requestBody": { "$ref": "#/components/requestBodies/Message" },
-        "responses": { "200": { "$ref": "#/components/responses/DeliveryResult" }, "400": { "$ref": "#/components/responses/Error" }, "401": { "$ref": "#/components/responses/Unauthorized" } },
+        "responses": { "200": { "$ref": "#/components/responses/DeliveryResult" }, "400": { "$ref": "#/components/responses/Error" }, "401": { "$ref": "#/components/responses/Unauthorized" }, "409": { "$ref": "#/components/responses/IdempotencyConflict" } },
         "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
       }
     },

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -28,7 +28,7 @@ const { idempotencyMiddleware } = require('../lib/idempotency');
 function getRoutes(botOrGetter) {
 	const router = express.Router();
 	router.post('/webhook/alert', validateApiKey, idempotencyMiddleware, postAlert(botOrGetter));
-	router.post('/webhook/message', validateApiKey, postMessage(botOrGetter));
+	router.post('/webhook/message', validateApiKey, idempotencyMiddleware, postMessage(botOrGetter));
 	router.post('/webhook/expanded-analysis-alert', validateApiKey, idempotencyMiddleware, postExpandedAnalysisAlert(botOrGetter));
 	router.post('/webhook/market-scanner-alert', validateApiKey, idempotencyMiddleware, postMarketScannerAlert(botOrGetter));
 	router.post('/webhook/volume-confirmation', validateApiKey, postVolumeConfirmation());

--- a/tests/integration/generic-message-webhook.test.js
+++ b/tests/integration/generic-message-webhook.test.js
@@ -434,4 +434,61 @@ describe('POST /api/webhook/message - Generic message webhook', () => {
 
 		expect(res.body.error).toContain('Forbidden');
 	});
+
+	// ---------------------------------------------------------------------------
+	// Idempotency protection
+	// ---------------------------------------------------------------------------
+	describe('Idempotency protection', () => {
+		it('replays response and dispatches provider only once when sending identical request with same idempotency key', async () => {
+			const idempotencyKey = 'msg-key-123';
+			const payload = { message: 'Idempotent message test', channels: ['telegram'] };
+
+			// First call
+			const res1 = await request(app)
+				.post('/api/webhook/message')
+				.set('x-api-key', 'test-key')
+				.set('idempotency-key', idempotencyKey)
+				.send(payload)
+				.expect(200);
+
+			expect(res1.headers['idempotency-replay']).toBe('false');
+			expect(res1.body.success).toBe(true);
+			expect(mockBot.telegram.sendMessage).toHaveBeenCalledTimes(1);
+
+			// Second call (replay)
+			const res2 = await request(app)
+				.post('/api/webhook/message')
+				.set('x-api-key', 'test-key')
+				.set('idempotency-key', idempotencyKey)
+				.send(payload)
+				.expect(200);
+
+			expect(res2.headers['idempotency-replay']).toBe('true');
+			expect(res2.body.idempotencyReplayed).toBe(true);
+			expect(res2.body.success).toBe(true);
+			// Provider must still have been called only once
+			expect(mockBot.telegram.sendMessage).toHaveBeenCalledTimes(1);
+		});
+
+		it('returns 409 IDEMPOTENCY_CONFLICT when reusing key with different payload', async () => {
+			const idempotencyKey = 'msg-key-conflict';
+
+			await request(app)
+				.post('/api/webhook/message')
+				.set('x-api-key', 'test-key')
+				.set('idempotency-key', idempotencyKey)
+				.send({ message: 'First message', channels: ['telegram'] })
+				.expect(200);
+
+			const res = await request(app)
+				.post('/api/webhook/message')
+				.set('x-api-key', 'test-key')
+				.set('idempotency-key', idempotencyKey)
+				.send({ message: 'Different message', channels: ['telegram'] })
+				.expect(409);
+
+			expect(res.body.code).toBe('IDEMPOTENCY_CONFLICT');
+		});
+	});
 });
+


### PR DESCRIPTION
feat: make generic-message delivery idempotent to prevent duplicate notifications (CB-97)

## Summary

Applies the established `idempotencyMiddleware` contract to `POST /api/webhook/message` to prevent duplicate notification dispatches when clients retry requests due to network timeouts or ambiguous responses. Replayed requests using the same `idempotency-key` return the original cached response with `Idempotency-Replay: true` header and `idempotencyReplayed: true` body flag without re-dispatching to Telegram, WhatsApp, or Discord channels.

## Key Changes

- **Routes**: Mounted `idempotencyMiddleware` on `POST /api/webhook/message` in [src/routes/index.js](file:///Users/fgvaleriop/repositorios/cabros-crypto-bot-telegram/src/routes/index.js#L31).
- **Integration Tests**: Added `Idempotency protection` test suite in [tests/integration/generic-message-webhook.test.js](file:///Users/fgvaleriop/repositorios/cabros-crypto-bot-telegram/tests/integration/generic-message-webhook.test.js) verifying replay response, single provider dispatch, and 409 conflict detection.
- **OpenAPI Contract**: Updated [src/openapi/openapi.json](file:///Users/fgvaleriop/repositorios/cabros-crypto-bot-telegram/src/openapi/openapi.json) to document `IdempotencyKey` parameter and `409` `IdempotencyConflict` response for `POST /api/webhook/message`.
- **Postman Collection**: Updated [CabrosBot.postman_collection.json](file:///Users/fgvaleriop/repositorios/cabros-crypto-bot-telegram/CabrosBot.postman_collection.json) to include response examples for successful replay (`200 OK`) and payload conflict (`409 Conflict`).

## Technical Implementation

Uses shared `idempotencyMiddleware` from [src/lib/idempotency.js](file:///Users/fgvaleriop/repositorios/cabros-crypto-bot-telegram/src/lib/idempotency.js) and `IdempotencyService` from `src/services/storage/IdempotencyService.js`:
1. First-time requests with `idempotency-key` (header, body, or query) execute normally and store successful (<500) responses.
2. Sequential or concurrent matching requests replay the cached response with `Idempotency-Replay: true` without invoking notification providers.
3. Reusing an idempotency key with a different message body, channel selection, or destination override returns `409 IDEMPOTENCY_CONFLICT`.
4. Un-keyed requests preserve original delivery behavior.

## Testing

- `pnpm test -- tests/integration/generic-message-webhook.test.js` (25/25 passed)

## References

- **GitHub Issue**: [#240](https://github.com/francovp/cabros-bot/issues/240)
- **Linear**: [CB-97](https://linear.app/knil/issue/CB-97/gh-240-make-generic-message-delivery-idempotent-to-prevent-duplicate)
