### PR TITLE
feat(news): add dry-run mode (CB-98)

### DIFF
--- a/CabrosBot.postman_collection.json
+++ b/CabrosBot.postman_collection.json
@@ -1298,6 +1298,53 @@
               ]
             }
           }
+        },
+        {
+          "name": "POST News Monitor (dry run)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              },
+              {
+                "key": "x-api-key",
+                "value": "{{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"crypto\": [\"BTCUSDT\"],\n  \"channels\": [\"telegram\", \"whatsapp\", \"discord\"]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/news-monitor?dryRun=true",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "news-monitor"
+              ],
+              "query": [
+                {
+                  "key": "dryRun",
+                  "value": "true"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "200 OK - Dry run",
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "body": "{\n  \"success\": true,\n  \"dryRun\": true,\n  \"results\": [{\n    \"symbol\": \"BTCUSDT\",\n    \"status\": \"analyzed\",\n    \"alert\": {\n      \"eventCategory\": \"price_surge\",\n      \"headline\": \"Bitcoin breaks resistance\"\n    },\n    \"deliveryResults\": [],\n    \"cached\": false\n  }],\n  \"summary\": {\n    \"total\": 1,\n    \"analyzed\": 1,\n    \"cached\": 0,\n    \"timeout\": 0,\n    \"error\": 0,\n    \"quota_exhausted\": 0,\n    \"alerts_sent\": 1\n  },\n  \"requestedChannels\": [\"telegram\", \"whatsapp\", \"discord\"],\n  \"deliveredChannels\": [],\n  \"requestId\": \"req-dryrun123\"\n}"
+            }
+          ]
         }
       ]
     },

--- a/README.md
+++ b/README.md
@@ -420,6 +420,30 @@ Analyze financial news and market sentiment for crypto and stock symbols. Detect
 GET /api/news-monitor?crypto=BTCUSDT,ETHUSD&stocks=NVDA,MSFT
 ```
 
+Add `dryRun=true` to either GET or POST to run the same validation and analysis without sending Telegram, WhatsApp, or Discord notifications, claiming or writing news-dedup cache entries, or recording signal outcomes. The response includes `dryRun: true`, the generated alerts, the intended `requestedChannels`, and an empty `deliveredChannels` array. POST also accepts `dryRun: true` in the JSON body.
+
+```text
+GET /api/news-monitor?crypto=BTCUSDT&channels=telegram,whatsapp&dryRun=true
+POST /api/news-monitor?dryRun=true
+```
+
+Dry-run response excerpt:
+```json
+{
+  "success": true,
+  "dryRun": true,
+  "requestedChannels": ["telegram", "whatsapp"],
+  "deliveredChannels": [],
+  "results": [{
+    "symbol": "BTCUSDT",
+    "status": "analyzed",
+    "alert": { "eventCategory": "price_surge", "headline": "Bitcoin breaks resistance" },
+    "deliveryResults": [],
+    "cached": false
+  }]
+}
+```
+
 **Response:**
 ```json
 {

--- a/agents.md
+++ b/agents.md
@@ -539,6 +539,8 @@ The system provides an HTTP endpoint (`/api/news-monitor`) that analyzes financi
 8. Filtered alerts sent to all enabled channels (Telegram, WhatsApp) via existing NotificationManager in parallel
 9. Returns 200 OK with per-symbol results: status (analyzed/cached/timeout/error), detected alerts, delivery results, metadata (totalDurationMs, cached, requestId), and summary counters including `quota_exhausted` for exhausted Gemini 429 retries.
 
+**Dry-run request mode:** Add `dryRun=true` to GET or POST `/api/news-monitor` (query parameter; POST also accepts the boolean body field) to run validation and analysis without notification delivery, deduplication cache reads/claims/writes, or signal-outcome persistence. The response includes `dryRun: true`, generated alerts, intended `requestedChannels`, and an empty `deliveredChannels` array. Dry runs bypass cached results so operators inspect fresh analysis output.
+
 **Configuration**:
 - `ENABLE_NEWS_MONITOR` — Feature flag (default: false for safe rollout)
 - `ENABLE_NEWS_MONITOR_TEST_MODE` — Expose news monitor test-mode state in `/api/status` and `/api/capabilities` (default: false)
@@ -742,6 +744,7 @@ See `/specs/TERMINOLOGY_GUIDE.md` for extended discussion and examples.
 - GH-182 / CB-77: malformed or no-domain grounding sources count toward the declared UNKNOWN `0.5` quality tier instead of contributing zero; regression coverage lives in `tests/unit/event-detection.test.js`.
 - GH-187 / CB-79: added authenticated `GET /api/jobs` with bounded `status`, `type`, and `limit` filters; `JobRepository.list()` merges Firestore and memory records, while `JobService.listJobs()` omits expired terminal jobs and returns metadata-only summaries.
 - GH-239 / CB-96: job creation, retry, and retry-failed endpoints now use the shared bounded in-memory idempotency middleware, replay matching responses, and reject fingerprint conflicts with `409 IDEMPOTENCY_CONFLICT`; OpenAPI, README, Postman, and integration coverage were updated.
+- GH-241 / CB-98: `/api/news-monitor` supports opt-in dry-run analysis for GET and POST requests; it returns generated alerts and intended routing while skipping notification delivery, deduplication cache mutation, and signal-outcome persistence. OpenAPI, README, Postman, and integration coverage were updated.
 - GH-183 / CB-78: Azure, OpenRouter, and Cloudflare `llmCallv2()` results now return normalized token usage for downstream `tokenUsage` aggregation; the shared normalizer accepts OpenAI-compatible `prompt_tokens`, `completion_tokens`, and `total_tokens` fields.
 - GH-199 / CB-83: `detect-unused-features` derives disabled flags, status mappings, indirect env lookups, `.env.example` gaps, and Sentry profiling findings from the fresh protected capabilities response and current repository files; dated snapshots are guidance-free and a healthy-data dry run guards against stale issues.
 

--- a/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
@@ -317,7 +317,7 @@ class NewsAnalyzer {
    * @param {string} requestId - Correlation ID for tracing
    * @returns {Promise<Object[]>} Array of AnalysisResult objects
    */
-	async analyzeSymbols(symbols, requestId, tokenUsage, routing = {}) {
+	async analyzeSymbols(symbols, requestId, tokenUsage, routing = {}, options = {}) {
 		const limit = Math.min(this.geminiConcurrency, symbols.length);
 		const results = [];
 		let nextIndex = 0;
@@ -328,7 +328,7 @@ class NewsAnalyzer {
 				const currentIndex = nextIndex;
 				nextIndex += 1;
 				const symbol = symbols[currentIndex];
-				results[currentIndex] = await this.analyzeSymbol(symbol, requestId, tokenUsage, routing, batchStartedAt).catch(error => ({
+				results[currentIndex] = await this.analyzeSymbol(symbol, requestId, tokenUsage, routing, batchStartedAt, options).catch(error => ({
 					symbol,
 					status: AnalysisStatus.ERROR,
 					error: {
@@ -347,7 +347,7 @@ class NewsAnalyzer {
 		return results;
 	}
 
-	async runSymbolAnalysisWithRetry(symbol, requestId, tokenUsage, routing, startedAt) {
+	async runSymbolAnalysisWithRetry(symbol, requestId, tokenUsage, routing, startedAt, options = {}) {
 		let attempt = 0;
 		let lastQuotaError = null;
 
@@ -364,7 +364,7 @@ class NewsAnalyzer {
 					timeoutHandle = setTimeout(() => reject(new Error('TIMEOUT')), remainingMs);
 				});
 				return await Promise.race([
-					this.analyzeSymbolInternal(symbol, requestId, tokenUsage, routing),
+					this.analyzeSymbolInternal(symbol, requestId, tokenUsage, routing, options),
 					timeoutPromise,
 				]);
 			} catch (error) {
@@ -403,7 +403,7 @@ class NewsAnalyzer {
    * @param {string} requestId - Correlation ID
    * @returns {Promise<Object>} AnalysisResult object
    */
-	async analyzeSymbol(symbol, requestId, tokenUsage, routing = {}, startedAt = Date.now()) {
+	async analyzeSymbol(symbol, requestId, tokenUsage, routing = {}, startedAt = Date.now(), options = {}) {
 		const startTime = startedAt;
 		const analysis = {
 			symbol,
@@ -415,7 +415,7 @@ class NewsAnalyzer {
 
 		try {
 			// Attempt to run analysis with timeout
-			const result = await this.runSymbolAnalysisWithRetry(symbol, requestId, tokenUsage, routing, startTime);
+			const result = await this.runSymbolAnalysisWithRetry(symbol, requestId, tokenUsage, routing, startTime, options);
 
 			return {
 				...analysis,
@@ -445,29 +445,33 @@ class NewsAnalyzer {
    * @param {string} requestId - Correlation ID
    * @returns {Promise<Object>} Partial AnalysisResult (status, alert, etc.)
    */
-	async analyzeSymbolInternal(symbol, requestId, tokenUsage, routing = {}) {
-		// Try cache first
-		for (const category of Object.values(EventCategory)) {
-			if (category === EventCategory.NONE) continue;
+	async analyzeSymbolInternal(symbol, requestId, tokenUsage, routing = {}, options = {}) {
+		const { dryRun = false } = options;
 
-			const cached = await this.cache.get(symbol, category);
-			if (cached) {
-				console.debug('[Analyzer] Returning cached result:', symbol, category);
-				let deliveryResults = cached.deliveryResults;
-				if (cached.alert) {
-					const notificationMgr = getNotificationManager();
-					if (shouldRedeliverCachedAlertForRequest(notificationMgr, cached, routing)) {
-						deliveryResults = await sendWithNotificationRouting(notificationMgr, cached.alert, routing);
-					} else if (!notificationMgr) {
-						deliveryResults = [];
+		// Try cache first
+		if (!dryRun) {
+			for (const category of Object.values(EventCategory)) {
+				if (category === EventCategory.NONE) continue;
+
+				const cached = await this.cache.get(symbol, category);
+				if (cached) {
+					console.debug('[Analyzer] Returning cached result:', symbol, category);
+					let deliveryResults = cached.deliveryResults;
+					if (cached.alert) {
+						const notificationMgr = getNotificationManager();
+						if (shouldRedeliverCachedAlertForRequest(notificationMgr, cached, routing)) {
+							deliveryResults = await sendWithNotificationRouting(notificationMgr, cached.alert, routing);
+						} else if (!notificationMgr) {
+							deliveryResults = [];
+						}
 					}
+					return {
+						status: AnalysisStatus.CACHED,
+						alert: cached.alert,
+						deliveryResults,
+						cached: true,
+					};
 				}
-				return {
-					status: AnalysisStatus.CACHED,
-					alert: cached.alert,
-					deliveryResults,
-					cached: true,
-				};
 			}
 		}
 
@@ -485,15 +489,17 @@ class NewsAnalyzer {
 
 		// If no event detected, cache and return
 		if (geminiAnalysis.event_category === EventCategory.NONE) {
-			await this.cache.set(symbol, EventCategory.NONE, {
-				alert: null,
-				analysisResult: {
-					symbol,
-					status: AnalysisStatus.ANALYZED,
-					cached: false,
-					requestId,
-				},
-			});
+			if (!dryRun) {
+				await this.cache.set(symbol, EventCategory.NONE, {
+					alert: null,
+					analysisResult: {
+						symbol,
+						status: AnalysisStatus.ANALYZED,
+						cached: false,
+						requestId,
+					},
+				});
+			}
 			return {
 				status: AnalysisStatus.ANALYZED,
 				alert: null,
@@ -504,15 +510,17 @@ class NewsAnalyzer {
 		// Check confidence threshold
 		if (geminiAnalysis.confidence < this.alertThreshold) {
 			console.info('[Analyzer] Confidence below threshold for', symbol, '-', geminiAnalysis.confidence.toFixed(2), '<', this.alertThreshold);
-			await this.cache.set(symbol, geminiAnalysis.event_category, {
-				alert: null,
-				analysisResult: {
-					symbol,
-					status: AnalysisStatus.ANALYZED,
-					cached: false,
-					requestId,
-				},
-			});
+			if (!dryRun) {
+				await this.cache.set(symbol, geminiAnalysis.event_category, {
+					alert: null,
+					analysisResult: {
+						symbol,
+						status: AnalysisStatus.ANALYZED,
+						cached: false,
+						requestId,
+					},
+				});
+			}
 			return {
 				status: AnalysisStatus.ANALYZED,
 				alert: null,
@@ -537,6 +545,16 @@ class NewsAnalyzer {
 		// Build alert object
 		const tokenUsageSummary = tokenUsage ? tokenUsage.toJSON() : null;
 		const alert = this.buildAlert(symbol, geminiAnalysis, marketContext, enrichmentMetadata, tokenUsageSummary);
+
+		if (dryRun) {
+			console.debug('[Analyzer] Dry-run mode: skipping delivery, signal outcome, and cache persistence');
+			return {
+				status: AnalysisStatus.ANALYZED,
+				alert,
+				deliveryResults: [],
+				cached: false,
+			};
+		}
 
 		// Claim the cache key atomically before delivering the alert to prevent race conditions
 		const claimed = await this.cache.claim(symbol, geminiAnalysis.event_category);

--- a/src/controllers/webhooks/handlers/newsMonitor/newsMonitor.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/newsMonitor.js
@@ -15,6 +15,7 @@ const { TokenUsageTracker } = require('../../../../lib/tokenUsage');
 const {
 	NotificationRoutingValidationError,
 	parseNotificationRouting,
+	validateNotificationRouting,
 	getRequestedChannels,
 	getDeliveredChannels,
 } = require('../../../../services/notification/requestRouting');
@@ -74,6 +75,9 @@ class NewsMonitorHandler {
 			const routing = req.method === 'GET'
 				? parseNotificationRouting(req.query, { allowQueryChannels: true })
 				: parseNotificationRouting(req.body);
+			if (dryRun) {
+				validateNotificationRouting(notificationManager, routing);
+			}
 			const { crypto, stocks } = this.parseRequest(req);
 			const allSymbols = [...(crypto || []), ...(stocks || [])];
 			const validationError = this.validateRequest(allSymbols);

--- a/src/controllers/webhooks/handlers/newsMonitor/newsMonitor.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/newsMonitor.js
@@ -19,6 +19,12 @@ const {
 	getDeliveredChannels,
 } = require('../../../../services/notification/requestRouting');
 
+function resolveDryRun(req) {
+	const queryFlag = req.query && (req.query.dryRun === 'true' || req.query.dryRun === true);
+	const bodyFlag = req.body && typeof req.body === 'object' && (req.body.dryRun === true || req.body.dryRun === 'true');
+	return queryFlag || bodyFlag;
+}
+
 class NewsMonitorHandler {
 	constructor() {
 		this.analyzer = getAnalyzer();
@@ -47,6 +53,7 @@ class NewsMonitorHandler {
 
 		try {
 			const requestSpan = sentryService.getActiveSpan();
+			const dryRun = resolveDryRun(req);
 
 			// Inject notification manager into analyzer (set once before analysis)
 			const notificationManager = getNotificationManager();
@@ -106,7 +113,7 @@ class NewsMonitorHandler {
 			let results;
 			let summary;
 			try {
-				results = await this.analyzer.analyzeSymbols(symbolsToAnalyze, requestId, tokenUsage, routing);
+				results = await this.analyzer.analyzeSymbols(symbolsToAnalyze, requestId, tokenUsage, routing, { dryRun });
 				summary = this.generateSummary(results);
 				if (analysisSpan && typeof analysisSpan.setAttribute === 'function') {
 					analysisSpan.setAttribute('news.quota_exhausted', summary.quota_exhausted);
@@ -128,6 +135,10 @@ class NewsMonitorHandler {
 				requestId,
 				tokenUsage: tokenUsage.toJSON(),
 			};
+
+			if (dryRun) {
+				response.dryRun = true;
+			}
 
 			if (!response.partial_success) {
 				delete response.partial_success;

--- a/src/controllers/webhooks/handlers/newsMonitor/types.ts
+++ b/src/controllers/webhooks/handlers/newsMonitor/types.ts
@@ -111,9 +111,12 @@ export interface AnalysisSummary {
  */
 export interface NewsMonitorResponse {
   success: boolean;
+  dryRun?: boolean;
   partial_success?: boolean;
   results: AnalysisResult[];
   summary: AnalysisSummary;
+  requestedChannels?: string[];
+  deliveredChannels?: string[];
   totalDurationMs: number;
   requestId: string;
 }
@@ -124,6 +127,10 @@ export interface NewsMonitorResponse {
 export interface NewsMonitorRequest {
   crypto?: string[];
   stocks?: string[];
+  dryRun?: boolean;
+  channels?: Array<'telegram' | 'whatsapp' | 'discord'>;
+  telegramChatId?: string;
+  whatsappChatId?: string;
 }
 
 /**

--- a/src/openapi/openapi.json
+++ b/src/openapi/openapi.json
@@ -194,12 +194,13 @@
     "/api/news-monitor": {
       "get": {
         "tags": ["News"], "summary": "Analyze configured or queried market symbols", "operationId": "getNewsMonitor",
-        "parameters": [{ "$ref": "#/components/parameters/CryptoSymbols" }, { "$ref": "#/components/parameters/StockSymbols" }],
+        "parameters": [{ "$ref": "#/components/parameters/CryptoSymbols" }, { "$ref": "#/components/parameters/StockSymbols" }, { "$ref": "#/components/parameters/DryRun" }],
         "responses": { "200": { "$ref": "#/components/responses/NewsMonitorAnalysisResult" }, "400": { "$ref": "#/components/responses/Error" }, "403": { "$ref": "#/components/responses/Error" } },
         "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
       },
       "post": {
         "tags": ["News"], "summary": "Analyze market symbols from a JSON request", "operationId": "postNewsMonitor",
+        "parameters": [{ "$ref": "#/components/parameters/DryRun" }],
         "requestBody": { "$ref": "#/components/requestBodies/NewsMonitor" },
         "responses": { "200": { "$ref": "#/components/responses/NewsMonitorAnalysisResult" }, "400": { "$ref": "#/components/responses/Error" }, "403": { "$ref": "#/components/responses/Error" } },
         "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
@@ -233,7 +234,7 @@
       "IdempotencyKeyHeader": { "name": "idempotency-key", "in": "header", "schema": { "type": "string", "minLength": 1 }, "description": "Optional replay key. Header form is recommended." },
       "IdempotencyKeyQueryCamel": { "name": "idempotencyKey", "in": "query", "schema": { "type": "string", "minLength": 1 }, "description": "Optional legacy-compatible replay key query parameter." },
       "IdempotencyKeyQuerySnake": { "name": "idempotency_key", "in": "query", "schema": { "type": "string", "minLength": 1 }, "description": "Optional legacy-compatible replay key query parameter." },
-      "DryRun": { "name": "dryRun", "in": "query", "schema": { "type": "boolean", "default": false } },
+      "DryRun": { "name": "dryRun", "in": "query", "description": "When true, analyze and return alerts without notification delivery, deduplication cache claims/writes, or signal-outcome persistence.", "schema": { "type": "boolean", "default": false } },
       "UseTradingViewData": { "name": "useTradingViewData", "in": "query", "schema": { "type": "boolean", "default": false } },
       "AlertListLimit": { "name": "limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 50 } },
       "JobListLimit": { "name": "limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 50 } },
@@ -262,7 +263,7 @@
       "Replay": { "content": { "application/json": { "schema": { "type": "object", "properties": { "channels": { "type": "array", "items": { "type": "string", "enum": ["telegram", "whatsapp", "discord"] } } } }, "example": { "channels": ["telegram"] } } } },
       "ScannerPreset": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ScannerPresetRequest" }, "example": { "name": "Daily Scan", "exchange": "BINANCE", "timeframe": "4h", "scans": ["top_gainers"], "limit": 5 } } } },
       "TradingViewJob": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/TradingViewJobRequest" }, "examples": { "expandedAnalysis": { "value": { "type": "expanded-analysis", "symbols": ["BINANCE:BTCUSDT"], "timeframe": "1D", "channels": ["telegram"], "telegramChatId": "-1001234567890" } }, "expandedAnalysisWithCallback": { "value": { "type": "expanded-analysis", "symbols": ["BINANCE:BTCUSDT", "NASDAQ:NVDA"], "timeframe": "4h", "callbackUrl": "https://myapp.example.com/job-done", "callbackSecret": "my-shared-secret", "callbackEvents": ["completed", "failed"], "timeoutMs": 120000 } }, "marketScanner": { "value": { "type": "market-scanner", "exchange": "BINANCE", "timeframe": "4h", "ranked": true, "includeMultiTimeframe": true, "channels": ["telegram"] } }, "marketScannerWithCallback": { "value": { "type": "market-scanner", "exchange": "BINANCE", "timeframe": "4h", "scans": ["top_gainers", "volume_breakout_scanner"], "ranked": true, "includeMultiTimeframe": true, "callbackUrl": "https://myapp.example.com/scan-done", "callbackEvents": ["completed", "failed", "timed_out"] } } } } } },
-      "NewsMonitor": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/NewsMonitorRequest" }, "example": { "crypto": ["BTCUSDT", "ETHUSD"], "stocks": ["NVDA"], "channels": ["telegram"] } } } }
+      "NewsMonitor": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/NewsMonitorRequest" }, "example": { "crypto": ["BTCUSDT", "ETHUSD"], "stocks": ["NVDA"], "channels": ["telegram"], "dryRun": false } } } }
     },
     "responses": {
       "Unauthorized": { "description": "API key rejected", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" }, "example": { "error": "Unauthorized", "code": "UNAUTHORIZED" } } } },
@@ -275,7 +276,7 @@
       "MessageIdempotencyConflict": { "description": "The generic-message idempotency key was already used with a different message or routing payload.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" }, "example": { "error": "Idempotency key was reused with a different payload", "code": "IDEMPOTENCY_CONFLICT" } } } },
       "DeliveryResult": { "description": "Per-channel delivery result", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DeliveryResult" }, "example": { "success": true, "results": [{ "channel": "telegram", "success": true }] } } } },
       "AnalysisResult": { "description": "Analysis and delivery result", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JsonObject" } } } },
-      "NewsMonitorAnalysisResult": { "description": "News monitor analysis and delivery result", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/NewsMonitorResponse" } } } },
+      "NewsMonitorAnalysisResult": { "description": "News monitor analysis and delivery result", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/NewsMonitorResponse" }, "examples": { "dryRun": { "summary": "Side-effect-free analysis", "value": { "success": true, "dryRun": true, "results": [{ "symbol": "BTCUSDT", "status": "analyzed", "alert": { "eventCategory": "price_surge", "headline": "Bitcoin breaks resistance", "confidence": 0.85 }, "deliveryResults": [], "cached": false, "requestId": "req-dryrun123" }], "summary": { "total": 1, "analyzed": 1, "cached": 0, "timeout": 0, "error": 0, "quota_exhausted": 0, "alerts_sent": 1 }, "requestedChannels": ["telegram", "whatsapp"], "deliveredChannels": [], "totalDurationMs": 850, "requestId": "req-dryrun123", "tokenUsage": {} } } } } } },
       "AlertList": { "description": "Stored alert page", "content": { "application/json": { "schema": { "type": "object", "properties": { "alerts": { "type": "array", "items": { "$ref": "#/components/schemas/JsonObject" } }, "nextCursor": { "type": ["string", "null"] } } } } } },
       "JobResult": { "description": "Asynchronous job state", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Job" } } } },
       "JobList": { "description": "Bounded list of sanitized asynchronous job summaries", "content": { "application/json": { "schema": { "type": "object", "required": ["success", "jobs"], "properties": { "success": { "type": "boolean" }, "jobs": { "type": "array", "items": { "$ref": "#/components/schemas/Job" } } } }, "example": { "success": true, "jobs": [{ "jobId": "8f8ef192-349f-4318-8547-0e6d628bf739", "type": "expanded-analysis", "status": "processing", "progress": { "total": 2, "current": 1 }, "createdAt": "2026-05-25T01:30:00.000Z", "updatedAt": "2026-05-25T01:30:05.000Z", "totalDurationMs": 5123 }] } } } },
@@ -339,12 +340,13 @@
         }
       },
       "TradingViewJobRequest": { "oneOf": [{ "allOf": [{ "type": "object", "required": ["type"], "properties": { "type": { "const": "expanded-analysis" } } }, { "$ref": "#/components/schemas/ExpandedAnalysisRequest" }, { "$ref": "#/components/schemas/CallbackFields" }] }, { "allOf": [{ "type": "object", "required": ["type"], "properties": { "type": { "const": "market-scanner" } } }, { "$ref": "#/components/schemas/MarketScannerRequest" }, { "$ref": "#/components/schemas/CallbackFields" }] }] },
-      "NewsMonitorRequest": { "type": "object", "properties": { "crypto": { "type": "array", "items": { "type": "string" } }, "stocks": { "type": "array", "items": { "type": "string" } }, "channels": { "type": "array", "minItems": 1, "items": { "type": "string", "enum": ["telegram", "whatsapp", "discord"] } }, "telegramChatId": { "type": "string", "minLength": 1 }, "whatsappChatId": { "type": "string", "minLength": 1 } } },
+      "NewsMonitorRequest": { "type": "object", "properties": { "crypto": { "type": "array", "items": { "type": "string" } }, "stocks": { "type": "array", "items": { "type": "string" } }, "dryRun": { "type": "boolean", "default": false, "description": "When true, analyze without notification delivery or persistence. The query parameter form is supported for GET and POST." }, "channels": { "type": "array", "minItems": 1, "items": { "type": "string", "enum": ["telegram", "whatsapp", "discord"] } }, "telegramChatId": { "type": "string", "minLength": 1 }, "whatsappChatId": { "type": "string", "minLength": 1 } } },
       "NewsMonitorResponse": {
         "type": "object",
         "required": ["success", "results", "summary", "requestId"],
         "properties": {
           "success": { "type": "boolean" },
+          "dryRun": { "type": "boolean", "description": "Present and true when analysis generated alerts without dispatching or persisting them." },
           "partial_success": { "type": "boolean" },
           "results": { "type": "array", "items": { "$ref": "#/components/schemas/JsonObject" } },
           "summary": {
@@ -359,8 +361,8 @@
               "alerts_sent": { "type": "integer" }
             }
           },
-          "requestedChannels": { "type": "array", "items": { "type": "string" } },
-          "deliveredChannels": { "type": "array", "items": { "type": "string" } },
+          "requestedChannels": { "type": "array", "items": { "type": "string" }, "description": "Channels selected for delivery; in dry-run mode these are intended channels." },
+          "deliveredChannels": { "type": "array", "items": { "type": "string" }, "description": "Channels that actually received alerts; empty in dry-run mode." },
           "totalDurationMs": { "type": "integer" },
           "requestId": { "type": "string" },
           "tokenUsage": { "$ref": "#/components/schemas/JsonObject" }

--- a/src/services/notification/requestRouting.js
+++ b/src/services/notification/requestRouting.js
@@ -101,18 +101,26 @@ async function sendWithNotificationRouting(notificationManager, alert, routing =
 	};
 
 	if (routing.channels) {
-		const enabledChannels = getRequestedChannels(notificationManager);
-		const unavailableChannels = routing.channels.filter((channel) => !enabledChannels.includes(channel));
-		if (unavailableChannels.length > 0) {
-			throw new NotificationRoutingValidationError(
-				`Requested channel(s) disabled or misconfigured: ${unavailableChannels.join(', ')}`,
-				{ field: 'channels', unavailableChannels },
-			);
-		}
+		validateNotificationRouting(notificationManager, routing);
 		return notificationManager.sendToChannels(alertPayload, routing.channels, options);
 	}
 
 	return notificationManager.sendToAll(alertPayload, options);
+}
+
+function validateNotificationRouting(notificationManager, routing = {}) {
+	if (!routing.channels) {
+		return;
+	}
+
+	const enabledChannels = getRequestedChannels(notificationManager);
+	const unavailableChannels = routing.channels.filter((channel) => !enabledChannels.includes(channel));
+	if (unavailableChannels.length > 0) {
+		throw new NotificationRoutingValidationError(
+			`Requested channel(s) disabled or misconfigured: ${unavailableChannels.join(', ')}`,
+			{ field: 'channels', unavailableChannels },
+		);
+	}
 }
 
 function getRequestedChannels(notificationManager, routing = {}) {
@@ -137,6 +145,7 @@ module.exports = {
 	VALID_CHANNELS,
 	NotificationRoutingValidationError,
 	parseNotificationRouting,
+	validateNotificationRouting,
 	sendWithNotificationRouting,
 	getRequestedChannels,
 	getDeliveredChannels,

--- a/tests/integration/news-monitor-dry-run.test.js
+++ b/tests/integration/news-monitor-dry-run.test.js
@@ -1,0 +1,144 @@
+const request = require('supertest');
+const app = require('../../app');
+const { getRoutes } = require('../../src/routes');
+const { initializeNotificationServices } = require('../../src/controllers/webhooks/handlers/alert/alert');
+const { getCacheInstance } = require('../../src/controllers/webhooks/handlers/newsMonitor/cache');
+const signalOutcomeService = require('../../src/services/storage/SignalOutcomeService');
+
+jest.mock('../../src/services/grounding/gemini');
+jest.mock('../../src/services/grounding/genaiClient');
+jest.mock('../../src/services/storage/SignalOutcomeService', () => ({
+	isEnabled: jest.fn(),
+	recordSignal: jest.fn(),
+}));
+
+describe('News Monitor dry-run mode', () => {
+	const originalEnv = process.env;
+	let mockTelegramSendMessage;
+	let mockBot;
+	let mockFetch;
+	let cache;
+	let cacheSetSpy;
+	let cacheClaimSpy;
+
+	beforeEach(async () => {
+		process.env = {
+			...originalEnv,
+			WEBHOOK_API_KEY: 'test-key',
+			ENABLE_NEWS_MONITOR: 'true',
+			ENABLE_NEWS_MONITOR_TEST_MODE: 'true',
+			ENABLE_SIGNAL_OUTCOME_TRACKING: 'true',
+			ENABLE_TELEGRAM_BOT: 'true',
+			ENABLE_WHATSAPP_ALERTS: 'true',
+			ENABLE_DISCORD_ALERTS: 'true',
+			BOT_TOKEN: 'test-token',
+			TELEGRAM_CHAT_ID: '123456789',
+			WHATSAPP_API_URL: 'https://api.greenapi.com/waInstance123/',
+			WHATSAPP_API_KEY: 'test-whatsapp-key',
+			WHATSAPP_CHAT_ID: '120363000000000000@g.us',
+			DISCORD_WEBHOOK_URL: 'https://discord.example/webhook',
+			NEWS_ALERT_THRESHOLD: '0.7',
+			ENABLE_NEWS_MONITOR_PERSISTENT_DEDUP: 'false',
+		};
+
+		jest.clearAllMocks();
+		signalOutcomeService.isEnabled.mockReturnValue(true);
+		signalOutcomeService.recordSignal.mockResolvedValue('outcome-id');
+
+		const gemini = require('../../src/services/grounding/gemini');
+		gemini.analyzeNewsForSymbol.mockResolvedValue({
+			event_category: 'price_surge',
+			event_significance: 0.8,
+			sentiment_score: 0.9,
+			headline: 'Bitcoin surges on positive news',
+			confidence: 0.95,
+			sources: ['https://example.com/news'],
+		});
+
+		const genaiClient = require('../../src/services/grounding/genaiClient');
+		genaiClient.search.mockResolvedValue({
+			results: [],
+			searchResultText: '{"price":123.45,"change_24h":1.23,"context":"Mock market context"}',
+			totalResults: 0,
+		});
+
+		mockTelegramSendMessage = jest.fn().mockResolvedValue({ message_id: 'test-message-id' });
+		mockFetch = jest.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ idMessage: 'mock-message-id', id: 'discord-message-id' }),
+		});
+		global.fetch = mockFetch;
+		mockBot = {
+			telegram: {
+				sendMessage: mockTelegramSendMessage,
+				getMe: jest.fn().mockResolvedValue({ id: 123456789, username: 'TestBot' }),
+			},
+		};
+
+		await initializeNotificationServices(mockBot);
+		app.use('/api', getRoutes(mockBot));
+
+		cache = getCacheInstance();
+		cache.clear();
+		cacheSetSpy = jest.spyOn(cache, 'set');
+		cacheClaimSpy = jest.spyOn(cache, 'claim');
+	});
+
+	afterEach(() => {
+		cacheSetSpy?.mockRestore();
+		cacheClaimSpy?.mockRestore();
+		process.env = originalEnv;
+		if (app._router && app._router.stack && app._router.stack.length > 0) {
+			app._router.stack.pop();
+		}
+	});
+
+	it('GET returns generated alerts and intended channels without side effects', async () => {
+		const response = await request(app)
+			.get('/api/news-monitor?dryRun=true')
+			.set('x-api-key', 'test-key')
+			.query({ crypto: 'DRYBTC', channels: 'telegram,whatsapp,discord' })
+			.expect(200);
+
+		expect(response.body.dryRun).toBe(true);
+		expect(response.body.requestedChannels).toEqual(['telegram', 'whatsapp', 'discord']);
+		expect(response.body.deliveredChannels).toEqual([]);
+		expect(response.body.results[0]).toEqual(expect.objectContaining({
+			symbol: 'DRYBTC',
+			status: 'analyzed',
+			cached: false,
+		}));
+		expect(response.body.results[0].alert.headline).toBe('Bitcoin surges on positive news');
+		expect(mockTelegramSendMessage).not.toHaveBeenCalled();
+		expect(mockFetch).not.toHaveBeenCalled();
+		expect(cacheClaimSpy).not.toHaveBeenCalled();
+		expect(cacheSetSpy).not.toHaveBeenCalled();
+		expect(signalOutcomeService.recordSignal).not.toHaveBeenCalled();
+	});
+
+	it('POST returns generated alerts and intended channels without side effects', async () => {
+		const response = await request(app)
+			.post('/api/news-monitor?dryRun=true')
+			.set('x-api-key', 'test-key')
+			.send({
+				crypto: ['DRYETH'],
+				channels: ['telegram', 'whatsapp', 'discord'],
+			})
+			.expect(200);
+
+		expect(response.body.dryRun).toBe(true);
+		expect(response.body.requestedChannels).toEqual(['telegram', 'whatsapp', 'discord']);
+		expect(response.body.deliveredChannels).toEqual([]);
+		expect(response.body.results[0]).toEqual(expect.objectContaining({
+			symbol: 'DRYETH',
+			status: 'analyzed',
+			cached: false,
+		}));
+		expect(response.body.results[0].alert.headline).toBe('Bitcoin surges on positive news');
+		expect(mockTelegramSendMessage).not.toHaveBeenCalled();
+		expect(mockFetch).not.toHaveBeenCalled();
+		expect(cacheClaimSpy).not.toHaveBeenCalled();
+		expect(cacheSetSpy).not.toHaveBeenCalled();
+		expect(signalOutcomeService.recordSignal).not.toHaveBeenCalled();
+	});
+});

--- a/tests/integration/news-monitor-dry-run.test.js
+++ b/tests/integration/news-monitor-dry-run.test.js
@@ -1,7 +1,7 @@
 const request = require('supertest');
 const app = require('../../app');
 const { getRoutes } = require('../../src/routes');
-const { initializeNotificationServices } = require('../../src/controllers/webhooks/handlers/alert/alert');
+const { initializeNotificationServices, getNotificationManager } = require('../../src/controllers/webhooks/handlers/alert/alert');
 const { getCacheInstance } = require('../../src/controllers/webhooks/handlers/newsMonitor/cache');
 const signalOutcomeService = require('../../src/services/storage/SignalOutcomeService');
 
@@ -20,6 +20,7 @@ describe('News Monitor dry-run mode', () => {
 	let cache;
 	let cacheSetSpy;
 	let cacheClaimSpy;
+	let originalDiscordEnabled;
 
 	beforeEach(async () => {
 		process.env = {
@@ -77,6 +78,7 @@ describe('News Monitor dry-run mode', () => {
 
 		await initializeNotificationServices(mockBot);
 		app.use('/api', getRoutes(mockBot));
+		originalDiscordEnabled = getNotificationManager().channels.get('discord').enabled;
 
 		cache = getCacheInstance();
 		cache.clear();
@@ -85,6 +87,7 @@ describe('News Monitor dry-run mode', () => {
 	});
 
 	afterEach(() => {
+		getNotificationManager().channels.get('discord').enabled = originalDiscordEnabled;
 		cacheSetSpy?.mockRestore();
 		cacheClaimSpy?.mockRestore();
 		process.env = originalEnv;
@@ -140,5 +143,21 @@ describe('News Monitor dry-run mode', () => {
 		expect(cacheClaimSpy).not.toHaveBeenCalled();
 		expect(cacheSetSpy).not.toHaveBeenCalled();
 		expect(signalOutcomeService.recordSignal).not.toHaveBeenCalled();
+	});
+
+	it('rejects dry-run requests for disabled explicitly requested channels', async () => {
+		getNotificationManager().channels.get('discord').enabled = false;
+
+		const response = await request(app)
+			.get('/api/news-monitor?dryRun=true')
+			.set('x-api-key', 'test-key')
+			.query({ crypto: 'DRYBTC', channels: 'telegram,discord' })
+			.expect(400);
+
+		expect(response.body).toEqual(expect.objectContaining({
+			code: 'INVALID_REQUEST',
+			error: 'Requested channel(s) disabled or misconfigured: discord',
+		}));
+		expect(require('../../src/services/grounding/gemini').analyzeNewsForSymbol).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
feat(news): add dry-run mode (CB-98)

## Summary

Add an opt-in side-effect-free dry-run mode to GET and POST `/api/news-monitor`.

## Key Changes

### 🧪 Safe analysis preview

- Supports `dryRun=true` in the query string for GET and POST requests, plus the boolean POST body field.
- Returns generated alerts and intended `requestedChannels` with `dryRun: true` and empty `deliveredChannels`.
- Preserves the existing live delivery path when dry-run is omitted or false.

### 🛡️ Side-effect boundaries

- Dry runs bypass cached results to produce fresh analysis output.
- Dry runs skip notification dispatch, deduplication cache claims/writes, and signal-outcome persistence.

## Technical Implementation

### Architecture changes

- `NewsMonitorHandler` resolves the request-level dry-run flag and includes it in the response only when enabled.
- `NewsAnalyzer` propagates the option through symbol analysis and bypasses cache, delivery, and outcome side effects in dry-run mode.
- OpenAPI schema/types describe the request flag, response indicator, and intended-versus-delivered channel semantics.

### Dependencies Added

- None.

## Testing

### Pre-merge Verification

- `pnpm test -- tests/integration/news-monitor-dry-run.test.js` — 2/2 passed.
- `pnpm test -- tests/integration/news-monitor-dry-run.test.js tests/integration/news-monitor-basic.test.js tests/integration/news-monitor-cache.test.js tests/unit/openapi-contract.test.js` — 54/54 passed on rerun.
- `pnpm test -- tests/unit/analyzer.test.js tests/unit/news-monitor-handler.test.js tests/integration/news-monitor-dry-run.test.js` — 20/20 passed.
- `pnpm test` — aggregate suite exposed existing unrelated 400-response flakes in generic-message, jobs, status, and alert-grounding runs; the exact alert-grounding rerun passed 9/9 and the news-monitor suites passed in isolation/targeted combination.

### Test Coverage

- GET and POST alert-producing dry runs.
- Zero Telegram, WhatsApp, and Discord sends.
- Zero cache claims/writes and signal-outcome persistence.

## Documentation Updates

- Updated `README.md`, `src/openapi/openapi.json`, `CabrosBot.postman_collection.json`, and `agents.md`.

## References

- GitHub: https://github.com/francovp/cabros-bot/issues/241
- Linear: [CB-98](https://linear.app/knil/issue/CB-98/gh-241-add-side-effect-free-dry-run-for-news-monitor-analysis)

## Deployment Considerations

- No new environment variables or migrations.
- Use `dryRun=true` for operational validation before enabling live delivery changes.
